### PR TITLE
Fix missing incremental generator caching

### DIFF
--- a/src/NetEscapades.EnumGenerators/CompilationInfo.cs
+++ b/src/NetEscapades.EnumGenerators/CompilationInfo.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace NetEscapades.EnumGenerators;
+
+internal readonly struct CompilationInfo : IEquatable<CompilationInfo>
+{
+    public INamedTypeSymbol? EnumAttribute { get; }
+	public INamedTypeSymbol? DisplayAttribute { get; }
+	public INamedTypeSymbol? HasFlagsAttribute { get; }
+
+	public CompilationInfo(INamedTypeSymbol? enumAttribute, INamedTypeSymbol? displayAttribute, INamedTypeSymbol? hasFlagsAttribute)
+	{
+		EnumAttribute = enumAttribute;
+		DisplayAttribute = displayAttribute;
+		HasFlagsAttribute = hasFlagsAttribute;
+	}
+
+	public bool Equals(CompilationInfo other)
+	{
+		return SymbolEqualityComparer.Default.Equals(EnumAttribute, other.EnumAttribute)
+			&& SymbolEqualityComparer.Default.Equals(DisplayAttribute, other.DisplayAttribute)
+			&& SymbolEqualityComparer.Default.Equals(HasFlagsAttribute, other.HasFlagsAttribute);
+    }
+
+	public override int GetHashCode()
+	{
+		return SymbolEqualityComparer.Default.GetHashCode(EnumAttribute) *
+			SymbolEqualityComparer.Default.GetHashCode(DisplayAttribute) *
+			SymbolEqualityComparer.Default.GetHashCode(HasFlagsAttribute);
+	}
+}

--- a/src/NetEscapades.EnumGenerators/EnumToGenerate.cs
+++ b/src/NetEscapades.EnumGenerators/EnumToGenerate.cs
@@ -1,6 +1,6 @@
 namespace NetEscapades.EnumGenerators;
 
-public readonly struct EnumToGenerate
+public readonly struct EnumToGenerate : IEquatable<EnumToGenerate>
 {
     public readonly string Name;
     public readonly string FullyQualifiedName;
@@ -34,5 +34,17 @@ public readonly struct EnumToGenerate
         IsPublic = isPublic;
         FullyQualifiedName = fullyQualifiedName;
         IsDisplayAttributeUsed = isDisplayAttributeUsed;
+    }
+
+    public bool Equals(EnumToGenerate other)
+    {
+        return Name == other.Name &&
+            Namespace == other.Namespace &&
+            UnderlyingType == other.UnderlyingType &&
+            Names.All(other.Names.Contains) &&
+            HasFlags == other.HasFlags &&
+            IsPublic == other.IsPublic &&
+            FullyQualifiedName == other.FullyQualifiedName &&
+            IsDisplayAttributeUsed == other.IsDisplayAttributeUsed;
     }
 }

--- a/src/NetEscapades.EnumGenerators/EnumToGenerate.cs
+++ b/src/NetEscapades.EnumGenerators/EnumToGenerate.cs
@@ -12,7 +12,7 @@ public readonly struct EnumToGenerate : IEquatable<EnumToGenerate>
     /// <summary>
     /// Key is the enum name.
     /// </summary>
-    public readonly List<KeyValuePair<string, EnumValueOption>> Names;
+    public readonly List<(string Key, EnumValueOption Value)> Names;
 
     public readonly bool IsDisplayAttributeUsed;
 
@@ -22,7 +22,7 @@ public readonly struct EnumToGenerate : IEquatable<EnumToGenerate>
     string fullyQualifiedName,
     string underlyingType,
     bool isPublic,
-    List<KeyValuePair<string, EnumValueOption>> names,
+    List<(string Key, EnumValueOption Value)> names,
     bool hasFlags,
     bool isDisplayAttributeUsed)
     {
@@ -41,7 +41,7 @@ public readonly struct EnumToGenerate : IEquatable<EnumToGenerate>
         return Name == other.Name &&
             Namespace == other.Namespace &&
             UnderlyingType == other.UnderlyingType &&
-            Names.All(other.Names.Contains) &&
+            Names.SequenceEqual(other.Names) &&
             HasFlags == other.HasFlags &&
             IsPublic == other.IsPublic &&
             FullyQualifiedName == other.FullyQualifiedName &&

--- a/src/NetEscapades.EnumGenerators/EnumValueOption.cs
+++ b/src/NetEscapades.EnumGenerators/EnumValueOption.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetEscapades.EnumGenerators;
 
-public readonly struct EnumValueOption
+public readonly struct EnumValueOption : IEquatable<EnumValueOption>
 {
     /// <summary>
     /// Custom name setted by the <c>[Display(Name)]</c> attribute.
@@ -12,5 +12,11 @@ public readonly struct EnumValueOption
     {
         DisplayName = displayName;
         IsDisplayNameTheFirstPresence = isDisplayNameTheFirstPresence;
+    }
+
+    public bool Equals(EnumValueOption other)
+    {
+        return DisplayName == other.DisplayName &&
+            IsDisplayNameTheFirstPresence == other.IsDisplayNameTheFirstPresence;
     }
 }

--- a/tests/NetEscapades.EnumGenerators.Tests/SourceGenerationHelperSnapshotTests.cs
+++ b/tests/NetEscapades.EnumGenerators.Tests/SourceGenerationHelperSnapshotTests.cs
@@ -19,11 +19,11 @@ public class SourceGenerationHelperSnapshotTests
             "Something.Blah.ShortName",
             "int",
             isPublic: true,
-            new Dictionary<string, EnumValueOption>
+            new List<(string, EnumValueOption)>
             {
-                { "First", new EnumValueOption(null, false) }, 
-                { "Second", new EnumValueOption(null, false) }
-            }.ToList(),
+                ("First", new EnumValueOption(null, false) ), 
+                ("Second", new EnumValueOption(null, false))
+            },
             hasFlags: false,
             isDisplayAttributeUsed: false);
 
@@ -43,11 +43,11 @@ public class SourceGenerationHelperSnapshotTests
             "Something.Blah.ShortName",
             "int",
             isPublic: true,
-            new Dictionary<string, EnumValueOption>
+            new List<(string, EnumValueOption)>
             {
-                { "First", new EnumValueOption(null, false) },
-                { "Second", new EnumValueOption(null, false) }
-            }.ToList(),
+                ( "First", new EnumValueOption(null, false) ),
+                ( "Second", new EnumValueOption(null, false) )
+            },
             hasFlags: true,
             isDisplayAttributeUsed: false);
 


### PR DESCRIPTION
Hi,

First of all thank you for a awesome post (and i general great) post regarding [incremental generators](https://andrewlock.net/creating-a-source-generator-part-1-creating-an-incremental-source-generator/).

I was reading this [blog](https://www.thinktecture.com/en/net/roslyn-source-generators-performance/) and the [main documentation](https://github.com/dotnet/roslyn/blob/main/docs/features/incremental-generators.md#authoring-a-cache-friendly-generator) and both describes one shouldn't combine with the whole compilation, since this will trigger the flow of every key stroke in the IDE.

As an example, create a new library `ExampleGenerator` and have `ExampleGenerator.csproj` look like

````
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
	  <TargetFramework>netstandard2.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
	  <LangVersion>Latest</LangVersion>
  </PropertyGroup>

	<ItemGroup>
		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all" />
	</ItemGroup>
	
</Project>
````

Create file `ExampleGenerator.cs` with the following incremental generator
````
using Microsoft.CodeAnalysis;
using Microsoft.CodeAnalysis.CSharp.Syntax;
using Microsoft.CodeAnalysis.Text;
using System.Collections.Immutable;
using System.Text;

namespace ExampleGenerator
{
    [Generator]
    public class ExampleGenerator : IIncrementalGenerator
    {
        private static int counter;

        public void Initialize(IncrementalGeneratorInitializationContext context)
        {
            context.RegisterPostInitializationOutput(context => context.AddSource(
                "ExampleExtensionAttribute.g.cs", SourceText.From(@"
namespace Example
{
    [System.AttributeUsage(System.AttributeTargets.Enum)]
    public class ExampleExtensionAttribute : System.Attribute
    {}
}", Encoding.UTF8)));

            var classProvider = context.SyntaxProvider
                .CreateSyntaxProvider(
                    static (node, _) => node is EnumDeclarationSyntax m && m.AttributeLists.Count > 0,
                    static (c, _) => GetEnumDeclarationSyntax(c))
                .Where(static e => e is not null)
                .Collect()
                .Combine(context.CompilationProvider);

            context.RegisterSourceOutput(classProvider,
                static (spc, source) => Execute(source.Left, source.Right, spc));
        }

        private static void Execute(ImmutableArray<EnumDeclarationSyntax?> classes, Compilation compilation, SourceProductionContext context)
        {
            foreach (var c in classes)
            {
                context.AddSource($"Example.{c.Identifier.Text}.cs", $@"
// Counter: {Interlocked.Increment(ref counter)}

namespace Example
{{
   partial class {c.Identifier.Text}
   {{
   }}
}}
");
            }
        }

        private static EnumDeclarationSyntax? GetEnumDeclarationSyntax(GeneratorSyntaxContext context)
        {
            var enumDeclarationSyntax = (EnumDeclarationSyntax)context.Node;

            foreach (AttributeListSyntax attributeListSyntax in enumDeclarationSyntax.AttributeLists)
            {
                foreach (AttributeSyntax attributeSyntax in attributeListSyntax.Attributes)
                {
                    if (context.SemanticModel.GetSymbolInfo(attributeSyntax).Symbol is not IMethodSymbol attributeSymbol)
                    {
                        continue;
                    }

                    INamedTypeSymbol attributeContainingTypeSymbol = attributeSymbol.ContainingType;
                    string fullName = attributeContainingTypeSymbol.ToDisplayString();

                    if (fullName == "Example.ExampleExtensionAttribute")
                    {
                        return enumDeclarationSyntax;
                    }
                }
            }
            return null;
        }
    }
}
````

*Thanks to [Pawel Gerr](https://www.thinktecture.com/en/net/roslyn-source-generators-performance/) for the counter idea and [you](https://andrewlock.net/creating-a-source-generator-part-1-creating-an-incremental-source-generator/) for example how find enums with attributes.*

Now create a console project `ExampleConsole` and have `ExampleConsole.csproj` look like
````
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net6.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
  </PropertyGroup>

  <ItemGroup>
    <ProjectReference Include="..\ExampleGenerator\ExampleGenerator.csproj"
					      ReferenceOutputAssembly="false"
                          OutputItemType="Analyzer" />
  </ItemGroup>

</Project>
````

Create three files with enums, two which have the attribute.

`SomeOther.cs`
````
namespace ExampleConsole
{
    internal enum SomeOther
    {
    }
}
````
`Bar.cs`
````
namespace ExampleConsole
{
    [ExampleExtension]
    internal enum Bar
    {
    }
}
````
`Foo.cs`
````
namespace ExampleConsole
{
    [ExampleExtension]
    internal enum Foo
    {
    }
}
````

Now if you do ANY changes to any file, you can see in Dependencies->Analyzers->ExampleGenerator that both `Example.Bar.cs` and `Example.Foo.cs` have their counter increased.

The best solution would be to avoid the `.Collect()` and just provide `IncrementalValuesProvider` instead of a `IncrementalValueProvider`. Since you are already creating a new file for each syntax, the change is just to avoid the loop.

Hope you have the time to look at my PR - please let me now any comments and thoughts. 