### PR TITLE
Added ToStringFastLowerCase

### DIFF
--- a/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
+++ b/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
@@ -93,6 +93,31 @@ namespace ").Append(enumToGenerate.Namespace).Append(@"
                 _ => value.ToString(),
             };");
 
+        sb.Append(@"
+
+        public static string ToStringFastLowerCase(this ").Append(enumToGenerate.FullyQualifiedName).Append(@" value)
+            => value switch
+            {");
+        foreach (var member in enumToGenerate.Names)
+        {
+            sb.Append(@"
+                ").Append(enumToGenerate.FullyQualifiedName).Append('.').Append(member.Key)
+                .Append(" => ");
+
+            if (member.Value.DisplayName is null)
+            {
+                sb.Append("\"").Append(member.Key.ToLowerInvariant()).Append("\",");
+            }
+            else
+            {
+                sb.Append('"').Append(member.Value.DisplayName).Append(@""",");
+            }
+        }
+
+        sb.Append(@"
+                _ => value.ToString().ToLowerInvariant(),
+            };");
+
         if (enumToGenerate.HasFlags)
         {
             sb.Append(@"

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInNamespaceExtensionsTests.cs
@@ -30,6 +30,8 @@ public class EnumInNamespaceExtensionsTests : ExtensionTests<EnumInNamespace>
     };
 
     protected override string ToStringFast(EnumInNamespace value) => value.ToStringFast();
+    protected override string ToStringFastLowerCase(EnumInNamespace value)=> value.ToStringFastLowerCase();
+
     protected override bool IsDefined(EnumInNamespace value) => EnumInNamespaceExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => EnumInNamespaceExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
@@ -45,6 +47,10 @@ public class EnumInNamespaceExtensionsTests : ExtensionTests<EnumInNamespace>
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(EnumInNamespace value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastLowerCase(EnumInNamespace value) => GeneratesToStringFastLowerCaseTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDisplayNameInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDisplayNameInNamespaceExtensionsTests.cs
@@ -30,6 +30,8 @@ public class EnumWithDisplayNameInNamespaceExtensionsTests : ExtensionTests<Enum
     };
 
     protected override string ToStringFast(EnumWithDisplayNameInNamespace value) => value.ToStringFast();
+    protected override string ToStringFastLowerCase(EnumWithDisplayNameInNamespace value)=> value.ToStringFastLowerCase();
+
     protected override bool IsDefined(EnumWithDisplayNameInNamespace value) => EnumWithDisplayNameInNamespaceExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => EnumWithDisplayNameInNamespaceExtensions.IsDefined(name, allowMatchingMetadataAttribute);
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
@@ -45,6 +47,10 @@ public class EnumWithDisplayNameInNamespaceExtensionsTests : ExtensionTests<Enum
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(EnumWithDisplayNameInNamespace value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastLowerCase(EnumWithDisplayNameInNamespace value) => GeneratesToStringFastLowerCaseTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithSameDisplayNameExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithSameDisplayNameExtensionsTests.cs
@@ -30,6 +30,8 @@ public class EnumWithSameDisplayNameExtensionsTests : ExtensionTests<EnumWithSam
     };
 
     protected override string ToStringFast(EnumWithSameDisplayName value) => value.ToStringFast();
+    protected override string ToStringFastLowerCase(EnumWithSameDisplayName value)=> value.ToStringFastLowerCase();
+
     protected override bool IsDefined(EnumWithSameDisplayName value) => EnumWithSameDisplayNameExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => EnumWithSameDisplayNameExtensions.IsDefined(name, allowMatchingMetadataAttribute);
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
@@ -45,6 +47,10 @@ public class EnumWithSameDisplayNameExtensionsTests : ExtensionTests<EnumWithSam
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(EnumWithSameDisplayName value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastLowerCase(EnumWithSameDisplayName value) => GeneratesToStringFastLowerCaseTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/ExtensionTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/ExtensionTests.cs
@@ -10,6 +10,7 @@ namespace NetEscapades.EnumGenerators.IntegrationTests;
 public abstract class ExtensionTests<T> where T : struct
 {
     protected abstract string ToStringFast(T value);
+    protected abstract string ToStringFastLowerCase(T value);
     protected abstract bool IsDefined(T value);
     protected abstract bool IsDefined(string name, bool allowMatchingMetadataAttribute = false);
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
@@ -27,7 +28,18 @@ public abstract class ExtensionTests<T> where T : struct
 
         TryGetDisplayName(valueAsString, out var displayName);
         var expectedValue = displayName is null ? valueAsString : displayName;
-        
+
+        serialized.Should().Be(expectedValue);
+    }
+
+    protected void GeneratesToStringFastLowerCaseTest(T value)
+    {
+        var serialized = ToStringFastLowerCase(value);
+        var valueAsString = value.ToString()!.ToLowerInvariant();
+
+        TryGetDisplayName(valueAsString, out var displayName);
+        var expectedValue = displayName is null ? valueAsString : displayName;
+
         serialized.Should().Be(expectedValue);
     }
 
@@ -164,7 +176,7 @@ public abstract class ExtensionTests<T> where T : struct
                     {
                         return false;
                     }
-                    
+
                     return true;
                 }
             }

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/FlagsEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/FlagsEnumExtensionsTests.cs
@@ -32,6 +32,8 @@ public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum>
     };
 
     protected override string ToStringFast(FlagsEnum value) => value.ToStringFast();
+    protected override string ToStringFastLowerCase(FlagsEnum value) => value.ToStringFast();
+
     protected override bool IsDefined(FlagsEnum value) => FlagsEnumExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => FlagsEnumExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
@@ -47,6 +49,10 @@ public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum>
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(FlagsEnum value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastLowerCase(FlagsEnum value) => GeneratesToStringFastLowerCaseTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/LongEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/LongEnumExtensionsTests.cs
@@ -30,6 +30,8 @@ public class LongEnumExtensionsTests : ExtensionTests<LongEnum>
     };
 
     protected override string ToStringFast(LongEnum value) => value.ToStringFast();
+    protected override string ToStringFastLowerCase(LongEnum value) => value.ToStringFast();
+
     protected override bool IsDefined(LongEnum value) => LongEnumExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => LongEnumExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
@@ -45,6 +47,10 @@ public class LongEnumExtensionsTests : ExtensionTests<LongEnum>
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(LongEnum value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastLowerCase(LongEnum value) => GeneratesToStringFastLowerCaseTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]


### PR DESCRIPTION
Just added a method that allow to have the lowercase of the enum name.

Not sure about the tests because my local built created weird trailing space that make unable to run the test locally, but the code looks ok.

Let me know if is ok, or need to change something.

Thanks