### PR TITLE
Surpass 1591 Code Documentation Whine

### DIFF
--- a/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
+++ b/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
@@ -54,6 +54,9 @@ namespace NetEscapades.EnumGenerators
 using System;
 #endif
 ");
+
+        sb.AppendLine(@"#pragma warning disable 1591");
+
         if (!string.IsNullOrEmpty(enumToGenerate.Namespace))
         {
             sb.Append(@"
@@ -138,7 +141,7 @@ namespace ").Append(enumToGenerate.Namespace).Append(@"
             foreach (var member in enumToGenerate.Names)
             {
                 if (member.Value.DisplayName is not null && member.Value.IsDisplayNameTheFirstPresence)
-                    {
+                {
                     sb.Append(@"
                     """).Append(member.Value.DisplayName).Append(@""" => true,");
                 }
@@ -160,8 +163,8 @@ namespace ").Append(enumToGenerate.Namespace).Append(@"
             return name switch
             {");
         foreach (var member in enumToGenerate.Names)
-            {
-             sb.Append(@"
+        {
+            sb.Append(@"
                 nameof(").Append(enumToGenerate.FullyQualifiedName).Append('.').Append(member.Key).Append(@") => true,");
         }
 
@@ -176,8 +179,8 @@ namespace ").Append(enumToGenerate.Namespace).Append(@"
         public static bool IsDefined(in ReadOnlySpan<char> name) => IsDefined(name, allowMatchingMetadataAttribute: false);
 
         /// <summary>
-        /// Slower then the <see cref=""IsDefined(string, bool)"",
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// Slower then the <see cref=""IsDefined(string, bool)""/>,
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name=""name""></param>
         /// <param name=""allowMatchingMetadataAttribute""></param>
@@ -379,7 +382,7 @@ namespace ").Append(enumToGenerate.Namespace).Append(@"
 
         /// <summary>
         /// Slower then the <see cref=""TryParse(string, out ").Append(enumToGenerate.FullyQualifiedName).Append(@", bool, bool)""/>,
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name=""name""></param>
         /// <param name=""result""></param>
@@ -444,20 +447,20 @@ namespace ").Append(enumToGenerate.Namespace).Append(@"
             }
 ");
         }
-            sb.Append(@"
+        sb.Append(@"
             if (ignoreCase)
             {
                 switch (name)
                 {");
-            foreach (var member in enumToGenerate.Names)
-            {
-                sb.Append(@"
+        foreach (var member in enumToGenerate.Names)
+        {
+            sb.Append(@"
                     case ReadOnlySpan<char> current when current.Equals(nameof(").Append(enumToGenerate.FullyQualifiedName).Append('.').Append(member.Key).Append(@").AsSpan(), System.StringComparison.OrdinalIgnoreCase):
                         result = ").Append(enumToGenerate.FullyQualifiedName).Append('.').Append(member.Key).Append(@";
                         return true;");
-            }
+        }
 
-            sb.Append(@"
+        sb.Append(@"
                     case ReadOnlySpan<char> current when ").Append(enumToGenerate.UnderlyingType).Append(@".TryParse(name, out var numericResult):
                         result = (").Append(enumToGenerate.FullyQualifiedName).Append(@")numericResult;
                         return true;
@@ -470,15 +473,15 @@ namespace ").Append(enumToGenerate.Namespace).Append(@"
             {
                 switch (name)
                 {");
-            foreach (var member in enumToGenerate.Names)
-            {
-                sb.Append(@"
+        foreach (var member in enumToGenerate.Names)
+        {
+            sb.Append(@"
                     case ReadOnlySpan<char> current when current.Equals(nameof(").Append(enumToGenerate.FullyQualifiedName).Append('.').Append(member.Key).Append(@").AsSpan(), System.StringComparison.Ordinal):
                         result = ").Append(enumToGenerate.FullyQualifiedName).Append('.').Append(member.Key).Append(@";
                         return true;");
-            }
+        }
 
-            sb.Append(@"
+        sb.Append(@"
                     case ReadOnlySpan<char> current when ").Append(enumToGenerate.UnderlyingType).Append(@".TryParse(name, out var numericResult):
                         result = (").Append(enumToGenerate.FullyQualifiedName).Append(@")numericResult;
                         return true;
@@ -528,6 +531,8 @@ namespace ").Append(enumToGenerate.Namespace).Append(@"
 }");
         }
 
+        sb.AppendLine();
+        sb.Append(@"#pragma warning restore 1591");
         return sb.ToString();
     }
 }

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInChildNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInChildNamespace.verified.txt
@@ -11,6 +11,7 @@
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
 using System;
 #endif
+#pragma warning disable 1591
 
 namespace MyTestNameSpace
 {
@@ -54,8 +55,8 @@ namespace MyTestNameSpace
         public static bool IsDefined(in ReadOnlySpan<char> name) => IsDefined(name, allowMatchingMetadataAttribute: false);
 
         /// <summary>
-        /// Slower then the <see cref="IsDefined(string, bool)",
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// Slower then the <see cref="IsDefined(string, bool)"/>,
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="allowMatchingMetadataAttribute"></param>
@@ -155,7 +156,7 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Slower then the <see cref="TryParse(string, out MyTestNameSpace.MyEnum, bool, bool)"/>,
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="result"></param>
@@ -229,3 +230,4 @@ namespace MyTestNameSpace
         }
     }
 }
+#pragma warning restore 1591

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInGlobalNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInGlobalNamespace.verified.txt
@@ -11,6 +11,7 @@
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
 using System;
 #endif
+#pragma warning disable 1591
 
     public static partial class MyEnumExtensions
     {
@@ -52,8 +53,8 @@ using System;
         public static bool IsDefined(in ReadOnlySpan<char> name) => IsDefined(name, allowMatchingMetadataAttribute: false);
 
         /// <summary>
-        /// Slower then the <see cref="IsDefined(string, bool)",
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// Slower then the <see cref="IsDefined(string, bool)"/>,
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="allowMatchingMetadataAttribute"></param>
@@ -153,7 +154,7 @@ using System;
 
         /// <summary>
         /// Slower then the <see cref="TryParse(string, out MyEnum, bool, bool)"/>,
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="result"></param>
@@ -226,3 +227,4 @@ using System;
             };
         }
     }
+#pragma warning restore 1591

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInNestedClass.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInNestedClass.verified.txt
@@ -11,6 +11,7 @@
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
 using System;
 #endif
+#pragma warning disable 1591
 
 namespace MyTestNameSpace
 {
@@ -54,8 +55,8 @@ namespace MyTestNameSpace
         public static bool IsDefined(in ReadOnlySpan<char> name) => IsDefined(name, allowMatchingMetadataAttribute: false);
 
         /// <summary>
-        /// Slower then the <see cref="IsDefined(string, bool)",
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// Slower then the <see cref="IsDefined(string, bool)"/>,
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="allowMatchingMetadataAttribute"></param>
@@ -155,7 +156,7 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Slower then the <see cref="TryParse(string, out MyTestNameSpace.InnerClass.MyEnum, bool, bool)"/>,
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="result"></param>
@@ -229,3 +230,4 @@ namespace MyTestNameSpace
         }
     }
 }
+#pragma warning restore 1591

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomName.verified.txt
@@ -11,6 +11,7 @@
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
 using System;
 #endif
+#pragma warning disable 1591
 
 namespace MyTestNameSpace
 {
@@ -54,8 +55,8 @@ namespace MyTestNameSpace
         public static bool IsDefined(in ReadOnlySpan<char> name) => IsDefined(name, allowMatchingMetadataAttribute: false);
 
         /// <summary>
-        /// Slower then the <see cref="IsDefined(string, bool)",
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// Slower then the <see cref="IsDefined(string, bool)"/>,
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="allowMatchingMetadataAttribute"></param>
@@ -155,7 +156,7 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Slower then the <see cref="TryParse(string, out MyTestNameSpace.MyEnum, bool, bool)"/>,
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="result"></param>
@@ -229,3 +230,4 @@ namespace MyTestNameSpace
         }
     }
 }
+#pragma warning restore 1591

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespace.verified.txt
@@ -11,6 +11,7 @@
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
 using System;
 #endif
+#pragma warning disable 1591
 
 namespace A.B
 {
@@ -54,8 +55,8 @@ namespace A.B
         public static bool IsDefined(in ReadOnlySpan<char> name) => IsDefined(name, allowMatchingMetadataAttribute: false);
 
         /// <summary>
-        /// Slower then the <see cref="IsDefined(string, bool)",
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// Slower then the <see cref="IsDefined(string, bool)"/>,
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="allowMatchingMetadataAttribute"></param>
@@ -155,7 +156,7 @@ namespace A.B
 
         /// <summary>
         /// Slower then the <see cref="TryParse(string, out MyTestNameSpace.MyEnum, bool, bool)"/>,
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="result"></param>
@@ -229,3 +230,4 @@ namespace A.B
         }
     }
 }
+#pragma warning restore 1591

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespaceAndName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespaceAndName.verified.txt
@@ -11,6 +11,7 @@
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
 using System;
 #endif
+#pragma warning disable 1591
 
 namespace A.B
 {
@@ -54,8 +55,8 @@ namespace A.B
         public static bool IsDefined(in ReadOnlySpan<char> name) => IsDefined(name, allowMatchingMetadataAttribute: false);
 
         /// <summary>
-        /// Slower then the <see cref="IsDefined(string, bool)",
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// Slower then the <see cref="IsDefined(string, bool)"/>,
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="allowMatchingMetadataAttribute"></param>
@@ -155,7 +156,7 @@ namespace A.B
 
         /// <summary>
         /// Slower then the <see cref="TryParse(string, out MyTestNameSpace.MyEnum, bool, bool)"/>,
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="result"></param>
@@ -229,3 +230,4 @@ namespace A.B
         }
     }
 }
+#pragma warning restore 1591

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithDisplayName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithDisplayName.verified.txt
@@ -11,6 +11,7 @@
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
 using System;
 #endif
+#pragma warning disable 1591
 
 namespace MyTestNameSpace
 {
@@ -77,8 +78,8 @@ namespace MyTestNameSpace
         public static bool IsDefined(in ReadOnlySpan<char> name) => IsDefined(name, allowMatchingMetadataAttribute: false);
 
         /// <summary>
-        /// Slower then the <see cref="IsDefined(string, bool)",
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// Slower then the <see cref="IsDefined(string, bool)"/>,
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="allowMatchingMetadataAttribute"></param>
@@ -240,7 +241,7 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Slower then the <see cref="TryParse(string, out MyTestNameSpace.MyEnum, bool, bool)"/>,
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="result"></param>
@@ -362,3 +363,4 @@ namespace MyTestNameSpace
         }
     }
 }
+#pragma warning restore 1591

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithSameDisplayName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithSameDisplayName.verified.txt
@@ -11,6 +11,7 @@
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
 using System;
 #endif
+#pragma warning disable 1591
 
 namespace MyTestNameSpace
 {
@@ -76,8 +77,8 @@ namespace MyTestNameSpace
         public static bool IsDefined(in ReadOnlySpan<char> name) => IsDefined(name, allowMatchingMetadataAttribute: false);
 
         /// <summary>
-        /// Slower then the <see cref="IsDefined(string, bool)",
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// Slower then the <see cref="IsDefined(string, bool)"/>,
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="allowMatchingMetadataAttribute"></param>
@@ -232,7 +233,7 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Slower then the <see cref="TryParse(string, out MyTestNameSpace.MyEnum, bool, bool)"/>,
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="result"></param>
@@ -348,3 +349,4 @@ namespace MyTestNameSpace
         }
     }
 }
+#pragma warning restore 1591

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesEnumCorrectly.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesEnumCorrectly.verified.txt
@@ -11,6 +11,7 @@
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
 using System;
 #endif
+#pragma warning disable 1591
 
 namespace Something.Blah
 {
@@ -54,8 +55,8 @@ namespace Something.Blah
         public static bool IsDefined(in ReadOnlySpan<char> name) => IsDefined(name, allowMatchingMetadataAttribute: false);
 
         /// <summary>
-        /// Slower then the <see cref="IsDefined(string, bool)",
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// Slower then the <see cref="IsDefined(string, bool)"/>,
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="allowMatchingMetadataAttribute"></param>
@@ -155,7 +156,7 @@ namespace Something.Blah
 
         /// <summary>
         /// Slower then the <see cref="TryParse(string, out Something.Blah.ShortName, bool, bool)"/>,
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="result"></param>
@@ -229,3 +230,4 @@ namespace Something.Blah
         }
     }
 }
+#pragma warning restore 1591

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesFlagsEnumCorrectly.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesFlagsEnumCorrectly.verified.txt
@@ -11,6 +11,7 @@
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
 using System;
 #endif
+#pragma warning disable 1591
 
 namespace Something.Blah
 {
@@ -61,8 +62,8 @@ namespace Something.Blah
         public static bool IsDefined(in ReadOnlySpan<char> name) => IsDefined(name, allowMatchingMetadataAttribute: false);
 
         /// <summary>
-        /// Slower then the <see cref="IsDefined(string, bool)",
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// Slower then the <see cref="IsDefined(string, bool)"/>,
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="allowMatchingMetadataAttribute"></param>
@@ -162,7 +163,7 @@ namespace Something.Blah
 
         /// <summary>
         /// Slower then the <see cref="TryParse(string, out Something.Blah.ShortName, bool, bool)"/>,
-        /// bacause the <c>ReadOnlySpan<char></c> can't be cached like a string, tho it doesn't allocate memory./>
+        /// bacause the <c>ReadOnlySpan&lt;char&gt;</c> can't be cached like a string, tho it doesn't allocate memory./>
         /// </summary>
         /// <param name="name"></param>
         /// <param name="result"></param>
@@ -236,3 +237,4 @@ namespace Something.Blah
         }
     }
 }
+#pragma warning restore 1591


### PR DESCRIPTION
Hi,

If an organisation has documentation required for public members policy enabled the multitude of CS1591 warning gets produced on both IDE and SonarCloud level. While you can try to manipulate editor settings to ignore it you have to to do it in every place enum and I was not able to find workaround which works with SonarCloud.

This Pull Request disables CS1591 check against files generated by source generator. It also fixed two minor issues visual studio was reporting after disabling pragma warnings `<char>` being treated as an xml tag resulting in syntax error and see tag for one of the methods not being closed.  