### PR TITLE
Switch to `ForAttributeWithMetadataName`

### DIFF
--- a/.github/workflows/BuildAndPack.yml
+++ b/.github/workflows/BuildAndPack.yml
@@ -32,22 +32,17 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
-          include-prerelease: true
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.0.x'
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '2.1.x'
+          dotnet-version: |
+            7.0.x
+            6.0.x
+            5.0.x
+            3.1.x
+            2.1.x
       - name: Cache .nuke/temp, ~/.nuget/packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .nuke/temp
@@ -69,22 +64,17 @@ jobs:
     name: windows-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
-          include-prerelease: true
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.0.x'
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '2.1.x'
+          dotnet-version: |
+            7.0.x
+            6.0.x
+            5.0.x
+            3.1.x
+            2.1.x
       - name: Cache .nuke/temp, ~/.nuget/packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .nuke/temp
@@ -106,22 +96,17 @@ jobs:
     name: macOS-latest
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
-          include-prerelease: true
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.0.x'
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '2.1.x'
+          dotnet-version: |
+            7.0.x
+            6.0.x
+            5.0.x
+            3.1.x
+            2.1.x
       - name: Cache .nuke/temp, ~/.nuget/packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .nuke/temp

--- a/src/NetEscapades.EnumGenerators/EnumToGenerate.cs
+++ b/src/NetEscapades.EnumGenerators/EnumToGenerate.cs
@@ -1,6 +1,6 @@
 namespace NetEscapades.EnumGenerators;
 
-public readonly struct EnumToGenerate
+public readonly record struct EnumToGenerate
 {
     public readonly string Name;
     public readonly string FullyQualifiedName;
@@ -12,24 +12,24 @@ public readonly struct EnumToGenerate
     /// <summary>
     /// Key is the enum name.
     /// </summary>
-    public readonly List<KeyValuePair<string, EnumValueOption>> Names;
+    public readonly EquatableArray<(string Key, EnumValueOption Value)> Names;
 
     public readonly bool IsDisplayAttributeUsed;
 
     public EnumToGenerate(
-    string name,
-    string ns,
-    string fullyQualifiedName,
-    string underlyingType,
-    bool isPublic,
-    List<KeyValuePair<string, EnumValueOption>> names,
-    bool hasFlags,
-    bool isDisplayAttributeUsed)
+        string name,
+        string ns,
+        string fullyQualifiedName,
+        string underlyingType,
+        bool isPublic,
+        List<(string, EnumValueOption)> names,
+        bool hasFlags,
+        bool isDisplayAttributeUsed)
     {
         Name = name;
         Namespace = ns;
         UnderlyingType = underlyingType;
-        Names = names;
+        Names = new EquatableArray<(string, EnumValueOption)>(names.ToArray());
         HasFlags = hasFlags;
         IsPublic = isPublic;
         FullyQualifiedName = fullyQualifiedName;

--- a/src/NetEscapades.EnumGenerators/EnumValueOption.cs
+++ b/src/NetEscapades.EnumGenerators/EnumValueOption.cs
@@ -1,9 +1,9 @@
 ﻿namespace NetEscapades.EnumGenerators;
 
-public readonly struct EnumValueOption
+public readonly struct EnumValueOption : IEquatable<EnumValueOption>
 {
     /// <summary>
-    /// Custom name setted by the <c>[Display(Name)]</c> attribute.
+    /// Custom name set by the <c>[Display(Name)]</c> attribute.
     /// </summary>
     public string? DisplayName { get; }
     public bool IsDisplayNameTheFirstPresence { get; }
@@ -12,5 +12,11 @@ public readonly struct EnumValueOption
     {
         DisplayName = displayName;
         IsDisplayNameTheFirstPresence = isDisplayNameTheFirstPresence;
+    }
+    
+    public bool Equals(EnumValueOption other)
+    {
+        return DisplayName == other.DisplayName &&
+               IsDisplayNameTheFirstPresence == other.IsDisplayNameTheFirstPresence;
     }
 }

--- a/src/NetEscapades.EnumGenerators/EquatableArray.cs
+++ b/src/NetEscapades.EnumGenerators/EquatableArray.cs
@@ -1,0 +1,102 @@
+using System.Collections;
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+
+namespace NetEscapades.EnumGenerators;
+
+/// <summary>
+/// An immutable, equatable array. This is equivalent to <see cref="Array{T}"/> but with value equality support.
+/// </summary>
+/// <typeparam name="T">The type of values in the array.</typeparam>
+public readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnumerable<T>
+    where T : IEquatable<T>
+{
+    /// <summary>
+    /// The underlying <typeparamref name="T"/> array.
+    /// </summary>
+    private readonly T[]? _array;
+
+    /// <summary>
+    /// Creates a new <see cref="EquatableArray{T}"/> instance.
+    /// </summary>
+    /// <param name="array">The input <see cref="ImmutableArray{T}"/> to wrap.</param>
+    public EquatableArray(T[] array)
+    {
+        _array = array;
+    }
+
+    /// <sinheritdoc/>
+    public bool Equals(EquatableArray<T> array)
+    {
+        return AsSpan().SequenceEqual(array.AsSpan());
+    }
+
+    /// <sinheritdoc/>
+    public override bool Equals(object? obj)
+    {
+        return obj is EquatableArray<T> array && Equals(this, array);
+    }
+
+    /// <sinheritdoc/>
+    public override int GetHashCode()
+    {
+        if (_array is not T[] array)
+        {
+            return 0;
+        }
+
+        HashCode hashCode = default;
+
+        foreach (T item in array)
+        {
+            hashCode.Add(item);
+        }
+
+        return hashCode.ToHashCode();
+    }
+
+    /// <summary>
+    /// Returns a <see cref="ReadOnlySpan{T}"/> wrapping the current items.
+    /// </summary>
+    /// <returns>A <see cref="ReadOnlySpan{T}"/> wrapping the current items.</returns>
+    public ReadOnlySpan<T> AsSpan()
+    {
+        return _array.AsSpan();
+    }
+
+    /// <sinheritdoc/>
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+    {
+        return ((IEnumerable<T>)(_array ?? Array.Empty<T>())).GetEnumerator();
+    }    
+    
+    /// <sinheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return ((IEnumerable<T>)(_array ?? Array.Empty<T>())).GetEnumerator();
+    }
+
+    public int Count => _array?.Length ?? 0;
+
+    /// <summary>
+    /// Checks whether two <see cref="EquatableArray{T}"/> values are the same.
+    /// </summary>
+    /// <param name="left">The first <see cref="EquatableArray{T}"/> value.</param>
+    /// <param name="right">The second <see cref="EquatableArray{T}"/> value.</param>
+    /// <returns>Whether <paramref name="left"/> and <paramref name="right"/> are equal.</returns>
+    public static bool operator ==(EquatableArray<T> left, EquatableArray<T> right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Checks whether two <see cref="EquatableArray{T}"/> values are not the same.
+    /// </summary>
+    /// <param name="left">The first <see cref="EquatableArray{T}"/> value.</param>
+    /// <param name="right">The second <see cref="EquatableArray{T}"/> value.</param>
+    /// <returns>Whether <paramref name="left"/> and <paramref name="right"/> are not equal.</returns>
+    public static bool operator !=(EquatableArray<T> left, EquatableArray<T> right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/src/NetEscapades.EnumGenerators/HashCode.cs
+++ b/src/NetEscapades.EnumGenerators/HashCode.cs
@@ -1,0 +1,381 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace NetEscapades.EnumGenerators;
+
+/// <summary>
+/// Polyfill for .NET 6 HashCode  
+/// </summary>
+internal struct HashCode
+{
+    private static readonly uint s_seed = GenerateGlobalSeed();
+
+    private const uint Prime1 = 2654435761U;
+    private const uint Prime2 = 2246822519U;
+    private const uint Prime3 = 3266489917U;
+    private const uint Prime4 = 668265263U;
+    private const uint Prime5 = 374761393U;
+
+    private uint _v1, _v2, _v3, _v4;
+    private uint _queue1, _queue2, _queue3;
+    private uint _length;
+
+    private static uint GenerateGlobalSeed()
+    {
+        var buffer = new byte[sizeof(uint)];
+        new Random().NextBytes(buffer);
+        return BitConverter.ToUInt32(buffer, 0);
+    }
+
+    public static int Combine<T1>(T1 value1)
+    {
+        // Provide a way of diffusing bits from something with a limited
+        // input hash space. For example, many enums only have a few
+        // possible hashes, only using the bottom few bits of the code. Some
+        // collections are built on the assumption that hashes are spread
+        // over a larger space, so diffusing the bits may help the
+        // collection work more efficiently.
+
+        uint hc1 = (uint)(value1?.GetHashCode() ?? 0);
+
+        uint hash = MixEmptyState();
+        hash += 4;
+
+        hash = QueueRound(hash, hc1);
+
+        hash = MixFinal(hash);
+        return (int)hash;
+    }
+
+    public static int Combine<T1, T2>(T1 value1, T2 value2)
+    {
+        uint hc1 = (uint)(value1?.GetHashCode() ?? 0);
+        uint hc2 = (uint)(value2?.GetHashCode() ?? 0);
+
+        uint hash = MixEmptyState();
+        hash += 8;
+
+        hash = QueueRound(hash, hc1);
+        hash = QueueRound(hash, hc2);
+
+        hash = MixFinal(hash);
+        return (int)hash;
+    }
+
+    public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
+    {
+        uint hc1 = (uint)(value1?.GetHashCode() ?? 0);
+        uint hc2 = (uint)(value2?.GetHashCode() ?? 0);
+        uint hc3 = (uint)(value3?.GetHashCode() ?? 0);
+
+        uint hash = MixEmptyState();
+        hash += 12;
+
+        hash = QueueRound(hash, hc1);
+        hash = QueueRound(hash, hc2);
+        hash = QueueRound(hash, hc3);
+
+        hash = MixFinal(hash);
+        return (int)hash;
+    }
+
+    public static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
+    {
+        uint hc1 = (uint)(value1?.GetHashCode() ?? 0);
+        uint hc2 = (uint)(value2?.GetHashCode() ?? 0);
+        uint hc3 = (uint)(value3?.GetHashCode() ?? 0);
+        uint hc4 = (uint)(value4?.GetHashCode() ?? 0);
+
+        Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+        v1 = Round(v1, hc1);
+        v2 = Round(v2, hc2);
+        v3 = Round(v3, hc3);
+        v4 = Round(v4, hc4);
+
+        uint hash = MixState(v1, v2, v3, v4);
+        hash += 16;
+
+        hash = MixFinal(hash);
+        return (int)hash;
+    }
+
+    public static int Combine<T1, T2, T3, T4, T5>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
+    {
+        uint hc1 = (uint)(value1?.GetHashCode() ?? 0);
+        uint hc2 = (uint)(value2?.GetHashCode() ?? 0);
+        uint hc3 = (uint)(value3?.GetHashCode() ?? 0);
+        uint hc4 = (uint)(value4?.GetHashCode() ?? 0);
+        uint hc5 = (uint)(value5?.GetHashCode() ?? 0);
+
+        Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+        v1 = Round(v1, hc1);
+        v2 = Round(v2, hc2);
+        v3 = Round(v3, hc3);
+        v4 = Round(v4, hc4);
+
+        uint hash = MixState(v1, v2, v3, v4);
+        hash += 20;
+
+        hash = QueueRound(hash, hc5);
+
+        hash = MixFinal(hash);
+        return (int)hash;
+    }
+
+    public static int Combine<T1, T2, T3, T4, T5, T6>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6)
+    {
+        uint hc1 = (uint)(value1?.GetHashCode() ?? 0);
+        uint hc2 = (uint)(value2?.GetHashCode() ?? 0);
+        uint hc3 = (uint)(value3?.GetHashCode() ?? 0);
+        uint hc4 = (uint)(value4?.GetHashCode() ?? 0);
+        uint hc5 = (uint)(value5?.GetHashCode() ?? 0);
+        uint hc6 = (uint)(value6?.GetHashCode() ?? 0);
+
+        Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+        v1 = Round(v1, hc1);
+        v2 = Round(v2, hc2);
+        v3 = Round(v3, hc3);
+        v4 = Round(v4, hc4);
+
+        uint hash = MixState(v1, v2, v3, v4);
+        hash += 24;
+
+        hash = QueueRound(hash, hc5);
+        hash = QueueRound(hash, hc6);
+
+        hash = MixFinal(hash);
+        return (int)hash;
+    }
+
+    public static int Combine<T1, T2, T3, T4, T5, T6, T7>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7)
+    {
+        uint hc1 = (uint)(value1?.GetHashCode() ?? 0);
+        uint hc2 = (uint)(value2?.GetHashCode() ?? 0);
+        uint hc3 = (uint)(value3?.GetHashCode() ?? 0);
+        uint hc4 = (uint)(value4?.GetHashCode() ?? 0);
+        uint hc5 = (uint)(value5?.GetHashCode() ?? 0);
+        uint hc6 = (uint)(value6?.GetHashCode() ?? 0);
+        uint hc7 = (uint)(value7?.GetHashCode() ?? 0);
+
+        Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+        v1 = Round(v1, hc1);
+        v2 = Round(v2, hc2);
+        v3 = Round(v3, hc3);
+        v4 = Round(v4, hc4);
+
+        uint hash = MixState(v1, v2, v3, v4);
+        hash += 28;
+
+        hash = QueueRound(hash, hc5);
+        hash = QueueRound(hash, hc6);
+        hash = QueueRound(hash, hc7);
+
+        hash = MixFinal(hash);
+        return (int)hash;
+    }
+
+    public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8)
+    {
+        uint hc1 = (uint)(value1?.GetHashCode() ?? 0);
+        uint hc2 = (uint)(value2?.GetHashCode() ?? 0);
+        uint hc3 = (uint)(value3?.GetHashCode() ?? 0);
+        uint hc4 = (uint)(value4?.GetHashCode() ?? 0);
+        uint hc5 = (uint)(value5?.GetHashCode() ?? 0);
+        uint hc6 = (uint)(value6?.GetHashCode() ?? 0);
+        uint hc7 = (uint)(value7?.GetHashCode() ?? 0);
+        uint hc8 = (uint)(value8?.GetHashCode() ?? 0);
+
+        Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+        v1 = Round(v1, hc1);
+        v2 = Round(v2, hc2);
+        v3 = Round(v3, hc3);
+        v4 = Round(v4, hc4);
+
+        v1 = Round(v1, hc5);
+        v2 = Round(v2, hc6);
+        v3 = Round(v3, hc7);
+        v4 = Round(v4, hc8);
+
+        uint hash = MixState(v1, v2, v3, v4);
+        hash += 32;
+
+        hash = MixFinal(hash);
+        return (int)hash;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Initialize(out uint v1, out uint v2, out uint v3, out uint v4)
+    {
+        v1 = s_seed + Prime1 + Prime2;
+        v2 = s_seed + Prime2;
+        v3 = s_seed;
+        v4 = s_seed - Prime1;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint Round(uint hash, uint input)
+    {
+        return RotateLeft(hash + input * Prime2, 13) * Prime1;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint QueueRound(uint hash, uint queuedValue)
+    {
+        return RotateLeft(hash + queuedValue * Prime3, 17) * Prime4;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint MixState(uint v1, uint v2, uint v3, uint v4)
+    {
+        return RotateLeft(v1, 1) + RotateLeft(v2, 7) + RotateLeft(v3, 12) + RotateLeft(v4, 18);
+    }
+
+    private static uint MixEmptyState()
+    {
+        return s_seed + Prime5;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint MixFinal(uint hash)
+    {
+        hash ^= hash >> 15;
+        hash *= Prime2;
+        hash ^= hash >> 13;
+        hash *= Prime3;
+        hash ^= hash >> 16;
+        return hash;
+    }
+
+    public void Add<T>(T value)
+    {
+        Add(value?.GetHashCode() ?? 0);
+    }
+
+    public void Add<T>(T value, IEqualityComparer<T>? comparer)
+    {
+        Add(value is null ? 0 : (comparer?.GetHashCode(value) ?? value.GetHashCode()));
+    }
+
+    private void Add(int value)
+    {
+        // The original xxHash works as follows:
+        // 0. Initialize immediately. We can't do this in a struct (no
+        //    default ctor).
+        // 1. Accumulate blocks of length 16 (4 uints) into 4 accumulators.
+        // 2. Accumulate remaining blocks of length 4 (1 uint) into the
+        //    hash.
+        // 3. Accumulate remaining blocks of length 1 into the hash.
+
+        // There is no need for #3 as this type only accepts ints. _queue1,
+        // _queue2 and _queue3 are basically a buffer so that when
+        // ToHashCode is called we can execute #2 correctly.
+
+        // We need to initialize the xxHash32 state (_v1 to _v4) lazily (see
+        // #0) nd the last place that can be done if you look at the
+        // original code is just before the first block of 16 bytes is mixed
+        // in. The xxHash32 state is never used for streams containing fewer
+        // than 16 bytes.
+
+        // To see what's really going on here, have a look at the Combine
+        // methods.
+
+        uint val = (uint)value;
+
+        // Storing the value of _length locally shaves of quite a few bytes
+        // in the resulting machine code.
+        uint previousLength = _length++;
+        uint position = previousLength % 4;
+
+        // Switch can't be inlined.
+
+        if (position == 0)
+            _queue1 = val;
+        else if (position == 1)
+            _queue2 = val;
+        else if (position == 2)
+            _queue3 = val;
+        else // position == 3
+        {
+            if (previousLength == 3)
+                Initialize(out _v1, out _v2, out _v3, out _v4);
+
+            _v1 = Round(_v1, _queue1);
+            _v2 = Round(_v2, _queue2);
+            _v3 = Round(_v3, _queue3);
+            _v4 = Round(_v4, val);
+        }
+    }
+
+    public int ToHashCode()
+    {
+        // Storing the value of _length locally shaves of quite a few bytes
+        // in the resulting machine code.
+        uint length = _length;
+
+        // position refers to the *next* queue position in this method, so
+        // position == 1 means that _queue1 is populated; _queue2 would have
+        // been populated on the next call to Add.
+        uint position = length % 4;
+
+        // If the length is less than 4, _v1 to _v4 don't contain anything
+        // yet. xxHash32 treats this differently.
+
+        uint hash = length < 4 ? MixEmptyState() : MixState(_v1, _v2, _v3, _v4);
+
+        // _length is incremented once per Add(Int32) and is therefore 4
+        // times too small (xxHash length is in bytes, not ints).
+
+        hash += length * 4;
+
+        // Mix what remains in the queue
+
+        // Switch can't be inlined right now, so use as few branches as
+        // possible by manually excluding impossible scenarios (position > 1
+        // is always false if position is not > 0).
+        if (position > 0)
+        {
+            hash = QueueRound(hash, _queue1);
+            if (position > 1)
+            {
+                hash = QueueRound(hash, _queue2);
+                if (position > 2)
+                    hash = QueueRound(hash, _queue3);
+            }
+        }
+
+        hash = MixFinal(hash);
+        return (int)hash;
+    }
+
+#pragma warning disable 0809
+    // Obsolete member 'memberA' overrides non-obsolete member 'memberB'.
+    // Disallowing GetHashCode and Equals is by design
+
+    // * We decided to not override GetHashCode() to produce the hash code
+    //   as this would be weird, both naming-wise as well as from a
+    //   behavioral standpoint (GetHashCode() should return the object's
+    //   hash code, not the one being computed).
+
+    // * Even though ToHashCode() can be called safely multiple times on
+    //   this implementation, it is not part of the contract. If the
+    //   implementation has to change in the future we don't want to worry
+    //   about people who might have incorrectly used this type.
+
+    [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", error: true)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override int GetHashCode() => throw new NotSupportedException("Hash code not supported");
+
+    [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes.", error: true)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override bool Equals(object? obj) => throw new NotSupportedException("Equality not supported");
+#pragma warning restore 0809
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint RotateLeft(uint value, int offset)
+        => (value << offset) | (value >> (32 - offset));
+}

--- a/src/NetEscapades.EnumGenerators/NetEscapades.EnumGenerators.csproj
+++ b/src/NetEscapades.EnumGenerators/NetEscapades.EnumGenerators.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
     <ProjectReference Include="..\NetEscapades.EnumGenerators.Attributes\NetEscapades.EnumGenerators.Attributes.csproj" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
+++ b/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
@@ -45,7 +45,7 @@ namespace NetEscapades.EnumGenerators
 #endif
 ";
 
-    public static string GenerateExtensionClass(StringBuilder sb, EnumToGenerate enumToGenerate)
+    public static string GenerateExtensionClass(StringBuilder sb, in EnumToGenerate enumToGenerate)
     {
         sb
             .Append(Header)

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/NetEscapades.EnumGenerators.IntegrationTests.csproj
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/NetEscapades.EnumGenerators.IntegrationTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;$(TargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/NetEscapades.EnumGenerators.Nuget.Attributes.IntegrationTests/NetEscapades.EnumGenerators.Nuget.Attributes.IntegrationTests.csproj
+++ b/tests/NetEscapades.EnumGenerators.Nuget.Attributes.IntegrationTests/NetEscapades.EnumGenerators.Nuget.Attributes.IntegrationTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;$(TargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <DefineConstants>NETESCAPADES_ENUMGENERATORS_EMBED_ATTRIBUTES</DefineConstants>

--- a/tests/NetEscapades.EnumGenerators.Nuget.IntegrationTests/NetEscapades.EnumGenerators.Nuget.IntegrationTests.csproj
+++ b/tests/NetEscapades.EnumGenerators.Nuget.IntegrationTests/NetEscapades.EnumGenerators.Nuget.IntegrationTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;$(TargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/NetEscapades.EnumGenerators.Tests/NetEscapades.EnumGenerators.Tests.csproj
+++ b/tests/NetEscapades.EnumGenerators.Tests/NetEscapades.EnumGenerators.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;netcoreapp3.1;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;$(TargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/NetEscapades.EnumGenerators.Tests/NetEscapades.EnumGenerators.Tests.csproj
+++ b/tests/NetEscapades.EnumGenerators.Tests/NetEscapades.EnumGenerators.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Verify.Xunit" Version="14.3.0" />

--- a/tests/NetEscapades.EnumGenerators.Tests/SourceGenerationHelperSnapshotTests.cs
+++ b/tests/NetEscapades.EnumGenerators.Tests/SourceGenerationHelperSnapshotTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using VerifyXunit;
@@ -19,11 +18,11 @@ public class SourceGenerationHelperSnapshotTests
             "Something.Blah.ShortName",
             "int",
             isPublic: true,
-            new Dictionary<string, EnumValueOption>
+            new List<(string Key, EnumValueOption Value)>
             {
-                { "First", new EnumValueOption(null, false) }, 
-                { "Second", new EnumValueOption(null, false) }
-            }.ToList(),
+                ("First", new EnumValueOption(null, false)),
+                ("Second", new EnumValueOption(null, false)),
+            },
             hasFlags: false,
             isDisplayAttributeUsed: false);
 
@@ -43,11 +42,11 @@ public class SourceGenerationHelperSnapshotTests
             "Something.Blah.ShortName",
             "int",
             isPublic: true,
-            new Dictionary<string, EnumValueOption>
+            new List<(string, EnumValueOption)>
             {
-                { "First", new EnumValueOption(null, false) },
-                { "Second", new EnumValueOption(null, false) }
-            }.ToList(),
+                ("First", new EnumValueOption(null, false)),
+                ("Second", new EnumValueOption(null, false)),
+            },
             hasFlags: true,
             isDisplayAttributeUsed: false);
 


### PR DESCRIPTION
.NET 7 introduced an optimised api for source generation, `ForAttributeWithMetadataName`, which takes care of finding all types decorated with a given attribute, skipping any symbols where it's not possible, greatly reducing the perf impact.

This PR also introduces `EquatableArray` as a wrapper for a native array to ensure we correctly compare identical types, and avoid unnccessary output