### PR TITLE
Fix HasFlag() implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ public static partial class MyEnumExtensions
 }
 ```
 
+If you create a "Flags" `enum` by decorating it with the `[Flags]` attribute, an additional method is created, which provides a bitwise alternative to :
+
+```csharp
+public static bool HasFlagFast(this MyEnum value, MyEnum flag)
+    => flag == 0 ? true : (value & flag) == flag;
+```
+
 You can override the name of the extension class by setting `ExtensionClassName` in the attribute and/or the namespace of the class by setting `ExtensionClassNamespace`. By default, the class will be public if the enum is public, otherwise it will be internal.
 
 ## Embedding the attributes in your project

--- a/src/NetEscapades.EnumGenerators/EnumGenerator.cs
+++ b/src/NetEscapades.EnumGenerators/EnumGenerator.cs
@@ -10,7 +10,7 @@ public class EnumGenerator : IIncrementalGenerator
 {
     private const string DisplayAttribute = "System.ComponentModel.DataAnnotations.DisplayAttribute";
     private const string EnumExtensionsAttribute = "NetEscapades.EnumGenerators.EnumExtensionsAttribute";
-    private const string HasFlagsAttribute = "System.HasFlagsAttribute";
+    private const string FlagsAttribute = "System.FlagsAttribute";
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -55,8 +55,9 @@ public class EnumGenerator : IIncrementalGenerator
 
         foreach (AttributeData attributeData in enumSymbol.GetAttributes())
         {
-            if (attributeData.AttributeClass?.Name == "HasFlagsAttribute" &&
-                attributeData.AttributeClass.ToDisplayString() == HasFlagsAttribute)
+            if ((attributeData.AttributeClass?.Name == "FlagsAttribute" ||
+                 attributeData.AttributeClass?.Name == "Flags") &&
+                attributeData.AttributeClass.ToDisplayString() == FlagsAttribute)
             {
                 hasFlags = true;
                 continue;

--- a/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
+++ b/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
@@ -110,17 +110,15 @@ namespace ").Append(enumToGenerate.Namespace).Append(@"
 
         /// <summary>
         /// Determines whether one or more bit fields are set in the current instance.
-        /// Equivalent to calling <c>value.HasFlag(flag)</c> 
+        /// Equivalent to calling <see cref=""Enum.HasFlag(Enum)"" /> on <paramref name=""value""/>.
         /// </summary>
         /// <param name=""value"">The value of the instance to investiage</param>
         /// <param name=""flag"">The flag to check for</param>
         /// <returns><c>true</c> if the fields set in the flag are also set in the current instance; otherwise <c>false</c>.</returns>
-        public static bool HasFlag(this ").Append(enumToGenerate.FullyQualifiedName).Append(@" value, ").Append(enumToGenerate.FullyQualifiedName).Append(@" flag)
-            => value switch
-            {
-                0  => flag.Equals(0),
-                _ => (value & flag) != 0,
-            };");
+        /// <remarks>If the underlying value of <paramref name=""flag""/> is zero, the method returns true.
+        /// This is consistent with the behaviour of <see cref=""Enum.HasFlag(Enum)"" /></remarks>
+        public static bool HasFlagFast(this ").Append(enumToGenerate.FullyQualifiedName).Append(@" value, ").Append(enumToGenerate.FullyQualifiedName).Append(@" flag)
+            => flag == 0 ? true : (value & flag) == flag;");
         }
 
         sb.Append(@"

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/FlagsEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/FlagsEnumExtensionsTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace NetEscapades.EnumGenerators.IntegrationTests;
@@ -44,6 +46,12 @@ public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum>
         => FlagsEnumExtensions.TryParse(name, out parsed, ignoreCase);
 #endif
 
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="value"></param>
+    /// <remarks>If the underlying value of <paramref name="flag"/> is zero, the method returns true.
+    /// This is consistent with the behaviour of <see cref=""Enum.HasFlag(Enum)""></remarks>
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(FlagsEnum value) => GeneratesToStringFastTest(value);
@@ -62,16 +70,29 @@ public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum>
     public void GeneratesIsDefinedUsingNameAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: false);
 #endif
 
-    [Theory]
-    [InlineData(FlagsEnum.First)]
-    [InlineData(FlagsEnum.Second)]
-    [InlineData(FlagsEnum.First | FlagsEnum.Second)]
-    [InlineData(FlagsEnum.Third)]
-    [InlineData((FlagsEnum)65)]
-    public void HasFlags(FlagsEnum value)
+    public static IEnumerable<object[]> AllFlags()
     {
-        var flag = FlagsEnum.Second;
-        var isDefined = value.HasFlag(flag);
+        var values = new[]
+        {
+            FlagsEnum.First,
+            FlagsEnum.Second,
+            FlagsEnum.Third,
+            FlagsEnum.ThirdAndFourth,
+            FlagsEnum.First | FlagsEnum.Second,
+            (FlagsEnum)65,
+            (FlagsEnum)0,
+        };
+
+        return from v1 in values
+            from v2 in values
+            select new object[] { v1, v2 };
+    }
+    
+    [Theory]
+    [MemberData(nameof(AllFlags))]
+    public void HasFlags(FlagsEnum value, FlagsEnum flag)
+    {
+        var isDefined = value.HasFlagFast(flag);
 
         isDefined.Should().Be(value.HasFlag(flag));
     }

--- a/tests/NetEscapades.EnumGenerators.Tests/EnumGeneratorTests.cs
+++ b/tests/NetEscapades.EnumGenerators.Tests/EnumGeneratorTests.cs
@@ -188,4 +188,36 @@ namespace MyTestNameSpace
         Assert.Empty(diagnostics);
         return Verifier.Verify(output).UseDirectory("Snapshots");
     }
+
+    [Theory]
+    [InlineData("", "System.Flags")]
+    [InlineData("", "System.FlagsAttribute")]
+    [InlineData("using System;", "FlagsAttribute")]
+    [InlineData("using System;", "Flags")]
+    public Task CanGenerateEnumExtensionsForFlagsEnum(string usings, string attribute)
+    {
+        string input = $$"""
+        using NetEscapades.EnumGenerators;
+        {{usings}}
+
+        namespace MyTestNameSpace
+        {
+            [EnumExtensions, {{attribute}}]
+            public enum MyEnum
+            {
+                First = 1,
+                Second = 2,
+                Third = 4,
+            }
+        }
+        """;
+
+        var (diagnostics, output) = TestHelpers.GetGeneratedOutput<EnumGenerator>(input);
+
+        Assert.Empty(diagnostics);
+        return Verifier.Verify(output)
+            .UseTextForParameters("Params")
+            .DisableRequireUniquePrefix()
+            .UseDirectory("Snapshots");
+    }
 }

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsForFlagsEnum_Params.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsForFlagsEnum_Params.verified.txt
@@ -12,32 +12,33 @@
 using System;
 #endif
 
-namespace Something.Blah
+namespace MyTestNameSpace
 {
     /// <summary>
-    /// Extension methods for <see cref="Something.Blah.ShortName" />
+    /// Extension methods for <see cref="MyTestNameSpace.MyEnum" />
     /// </summary>
-    public static partial class ShortName
+    public static partial class MyEnumExtensions
     {
         /// <summary>
         /// The number of members in the enum.
         /// This is a non-distinct count of defined names.
         /// </summary>
-        public const int Length = 2;
+        public const int Length = 3;
 
         /// <summary>
-        /// Returns the string representation of the <see cref="Something.Blah.ShortName"/> value.
+        /// Returns the string representation of the <see cref="MyTestNameSpace.MyEnum"/> value.
         /// If the attribute is decorated with a <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute"/>, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
         /// <returns>The string representation of the value</returns>
-        public static string ToStringFast(this Something.Blah.ShortName value)
+        public static string ToStringFast(this MyTestNameSpace.MyEnum value)
             => value switch
             {
-                Something.Blah.ShortName.First => nameof(Something.Blah.ShortName.First),
-                Something.Blah.ShortName.Second => nameof(Something.Blah.ShortName.Second),
+                MyTestNameSpace.MyEnum.First => nameof(MyTestNameSpace.MyEnum.First),
+                MyTestNameSpace.MyEnum.Second => nameof(MyTestNameSpace.MyEnum.Second),
+                MyTestNameSpace.MyEnum.Third => nameof(MyTestNameSpace.MyEnum.Third),
                 _ => value.ToString(),
             };
 
@@ -50,7 +51,7 @@ namespace Something.Blah
         /// <returns><c>true</c> if the fields set in the flag are also set in the current instance; otherwise <c>false</c>.</returns>
         /// <remarks>If the underlying value of <paramref name="flag"/> is zero, the method returns true.
         /// This is consistent with the behaviour of <see cref="Enum.HasFlag(Enum)" /></remarks>
-        public static bool HasFlagFast(this Something.Blah.ShortName value, Something.Blah.ShortName flag)
+        public static bool HasFlagFast(this MyTestNameSpace.MyEnum value, MyTestNameSpace.MyEnum flag)
             => flag == 0 ? true : (value & flag) == flag;
 
         /// <summary>
@@ -58,11 +59,12 @@ namespace Something.Blah
         /// </summary>
         /// <param name="value">The value to check if it's defined</param>
         /// <returns><c>true</c> if the value exists in the enumeration, <c/>false</c> otherwise</returns>
-       public static bool IsDefined(Something.Blah.ShortName value)
+       public static bool IsDefined(MyTestNameSpace.MyEnum value)
             => value switch
             {
-                Something.Blah.ShortName.First => true,
-                Something.Blah.ShortName.Second => true,
+                MyTestNameSpace.MyEnum.First => true,
+                MyTestNameSpace.MyEnum.Second => true,
+                MyTestNameSpace.MyEnum.Third => true,
                 _ => false,
             };
 
@@ -86,8 +88,9 @@ namespace Something.Blah
         {
             return name switch
             {
-                nameof(Something.Blah.ShortName.First) => true,
-                nameof(Something.Blah.ShortName.Second) => true,
+                nameof(MyTestNameSpace.MyEnum.First) => true,
+                nameof(MyTestNameSpace.MyEnum.Second) => true,
+                nameof(MyTestNameSpace.MyEnum.Third) => true,
                 _ => false,
             };
         }
@@ -114,8 +117,9 @@ namespace Something.Blah
         {
             return name switch
             {
-                ReadOnlySpan<char> current when current.Equals(nameof(Something.Blah.ShortName.First).AsSpan(), System.StringComparison.Ordinal) => true,
-                ReadOnlySpan<char> current when current.Equals(nameof(Something.Blah.ShortName.Second).AsSpan(), System.StringComparison.Ordinal) => true,
+                ReadOnlySpan<char> current when current.Equals(nameof(MyTestNameSpace.MyEnum.First).AsSpan(), System.StringComparison.Ordinal) => true,
+                ReadOnlySpan<char> current when current.Equals(nameof(MyTestNameSpace.MyEnum.Second).AsSpan(), System.StringComparison.Ordinal) => true,
+                ReadOnlySpan<char> current when current.Equals(nameof(MyTestNameSpace.MyEnum.Third).AsSpan(), System.StringComparison.Ordinal) => true,
                 _ => false,
             };
         }
@@ -123,35 +127,35 @@ namespace Something.Blah
 
         /// <summary>
         /// Converts the string representation of the name or numeric value of
-        /// an <see cref="Something.Blah.ShortName" /> to the equivalent instance.
+        /// an <see cref="MyTestNameSpace.MyEnum" /> to the equivalent instance.
         /// The return value indicates whether the conversion succeeded.
         /// </summary>
         /// <param name="name">The case-sensitive string representation of the enumeration name or underlying value to convert</param>
         /// <param name="value">When this method returns, contains an object of type 
-        /// <see cref="Something.Blah.ShortName" /> whose
+        /// <see cref="MyTestNameSpace.MyEnum" /> whose
         /// value is represented by <paramref name="value"/> if the parse operation succeeds.
         /// If the parse operation fails, contains the default value of the underlying type
-        /// of <see cref="Something.Blah.ShortName" />. This parameter is passed uninitialized.</param>
+        /// of <see cref="MyTestNameSpace.MyEnum" />. This parameter is passed uninitialized.</param>
         /// <returns><c>true</c> if the value parameter was converted successfully; otherwise, <c>false</c>.</returns>
         public static bool TryParse(
 #if NETCOREAPP3_0_OR_GREATER
             [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
 #endif
             string? name, 
-            out Something.Blah.ShortName value)
+            out MyTestNameSpace.MyEnum value)
             => TryParse(name, out value, false, false);
 
         /// <summary>
         /// Converts the string representation of the name or numeric value of
-        /// an <see cref="Something.Blah.ShortName" /> to the equivalent instance.
+        /// an <see cref="MyTestNameSpace.MyEnum" /> to the equivalent instance.
         /// The return value indicates whether the conversion succeeded.
         /// </summary>
         /// <param name="name">The string representation of the enumeration name or underlying value to convert</param>
         /// <param name="value">When this method returns, contains an object of type 
-        /// <see cref="Something.Blah.ShortName" /> whose
+        /// <see cref="MyTestNameSpace.MyEnum" /> whose
         /// value is represented by <paramref name="value"/> if the parse operation succeeds.
         /// If the parse operation fails, contains the default value of the underlying type
-        /// of <see cref="Something.Blah.ShortName" />. This parameter is passed uninitialized.</param>
+        /// of <see cref="MyTestNameSpace.MyEnum" />. This parameter is passed uninitialized.</param>
         /// <param name="ignoreCase"><c>true</c> to read value in case insensitive mode; <c>false</c> to read value in case sensitive mode.</param>
         /// <returns><c>true</c> if the value parameter was converted successfully; otherwise, <c>false</c>.</returns>
         public static bool TryParse(
@@ -159,21 +163,21 @@ namespace Something.Blah
             [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
 #endif
             string? name, 
-            out Something.Blah.ShortName value,
+            out MyTestNameSpace.MyEnum value,
             bool ignoreCase) 
             => TryParse(name, out value, ignoreCase, false);
 
         /// <summary>
         /// Converts the string representation of the name or numeric value of
-        /// an <see cref="Something.Blah.ShortName" /> to the equivalent instance.
+        /// an <see cref="MyTestNameSpace.MyEnum" /> to the equivalent instance.
         /// The return value indicates whether the conversion succeeded.
         /// </summary>
         /// <param name="name">The string representation of the enumeration name or underlying value to convert</param>
         /// <param name="value">When this method returns, contains an object of type 
-        /// <see cref="Something.Blah.ShortName" /> whose
+        /// <see cref="MyTestNameSpace.MyEnum" /> whose
         /// value is represented by <paramref name="value"/> if the parse operation succeeds.
         /// If the parse operation fails, contains the default value of the underlying type
-        /// of <see cref="Something.Blah.ShortName" />. This parameter is passed uninitialized.</param>
+        /// of <see cref="MyTestNameSpace.MyEnum" />. This parameter is passed uninitialized.</param>
         /// <param name="ignoreCase"><c>true</c> to read value in case insensitive mode; <c>false</c> to read value in case sensitive mode.</param>
         /// <param name="allowMatchingMetadataAttribute">If <c>true</c>, considers the value included in metadata attributes such as
         /// <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute"/> when parsing, otherwise only considers the member names.</param>
@@ -183,7 +187,7 @@ namespace Something.Blah
             [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
 #endif
             string? name, 
-            out Something.Blah.ShortName value, 
+            out MyTestNameSpace.MyEnum value, 
             bool ignoreCase, 
             bool allowMatchingMetadataAttribute)
         {
@@ -191,14 +195,17 @@ namespace Something.Blah
             {
                 switch (name)
                 {
-                    case string s when s.Equals(nameof(Something.Blah.ShortName.First), System.StringComparison.OrdinalIgnoreCase):
-                        value = Something.Blah.ShortName.First;
+                    case string s when s.Equals(nameof(MyTestNameSpace.MyEnum.First), System.StringComparison.OrdinalIgnoreCase):
+                        value = MyTestNameSpace.MyEnum.First;
                         return true;
-                    case string s when s.Equals(nameof(Something.Blah.ShortName.Second), System.StringComparison.OrdinalIgnoreCase):
-                        value = Something.Blah.ShortName.Second;
+                    case string s when s.Equals(nameof(MyTestNameSpace.MyEnum.Second), System.StringComparison.OrdinalIgnoreCase):
+                        value = MyTestNameSpace.MyEnum.Second;
+                        return true;
+                    case string s when s.Equals(nameof(MyTestNameSpace.MyEnum.Third), System.StringComparison.OrdinalIgnoreCase):
+                        value = MyTestNameSpace.MyEnum.Third;
                         return true;
                     case string s when int.TryParse(name, out var val):
-                        value = (Something.Blah.ShortName)val;
+                        value = (MyTestNameSpace.MyEnum)val;
                         return true;
                     default:
                         value = default;
@@ -209,14 +216,17 @@ namespace Something.Blah
             {
                 switch (name)
                 {
-                    case nameof(Something.Blah.ShortName.First):
-                        value = Something.Blah.ShortName.First;
+                    case nameof(MyTestNameSpace.MyEnum.First):
+                        value = MyTestNameSpace.MyEnum.First;
                         return true;
-                    case nameof(Something.Blah.ShortName.Second):
-                        value = Something.Blah.ShortName.Second;
+                    case nameof(MyTestNameSpace.MyEnum.Second):
+                        value = MyTestNameSpace.MyEnum.Second;
+                        return true;
+                    case nameof(MyTestNameSpace.MyEnum.Third):
+                        value = MyTestNameSpace.MyEnum.Third;
                         return true;
                     case string s when int.TryParse(name, out var val):
-                        value = (Something.Blah.ShortName)val;
+                        value = (MyTestNameSpace.MyEnum)val;
                         return true;
                     default:
                         value = default;
@@ -228,35 +238,35 @@ namespace Something.Blah
 #if NETCOREAPP && !NETCOREAPP2_0 && !NETCOREAPP1_1 && !NETCOREAPP1_0
         /// <summary>
         /// Converts the span representation of the name or numeric value of
-        /// an <see cref="Something.Blah.ShortName" /> to the equivalent instance.
+        /// an <see cref="MyTestNameSpace.MyEnum" /> to the equivalent instance.
         /// The return value indicates whether the conversion succeeded.
         /// </summary>
         /// <param name="name">The span representation of the enumeration name or underlying value to convert</param>
         /// <param name="value">When this method returns, contains an object of type 
-        /// <see cref="Something.Blah.ShortName" /> whose
+        /// <see cref="MyTestNameSpace.MyEnum" /> whose
         /// value is represented by <paramref name="value"/> if the parse operation succeeds.
         /// If the parse operation fails, contains the default value of the underlying type
-        /// of <see cref="Something.Blah.ShortName" />. This parameter is passed uninitialized.</param>
+        /// of <see cref="MyTestNameSpace.MyEnum" />. This parameter is passed uninitialized.</param>
         /// <returns><c>true</c> if the value parameter was converted successfully; otherwise, <c>false</c>.</returns>
         public static bool TryParse(
 #if NETCOREAPP3_0_OR_GREATER
             [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
 #endif
             in ReadOnlySpan<char> name, 
-            out Something.Blah.ShortName value)
+            out MyTestNameSpace.MyEnum value)
             => TryParse(name, out value, false, false);
 
         /// <summary>
         /// Converts the span representation of the name or numeric value of
-        /// an <see cref="Something.Blah.ShortName" /> to the equivalent instance.
+        /// an <see cref="MyTestNameSpace.MyEnum" /> to the equivalent instance.
         /// The return value indicates whether the conversion succeeded.
         /// </summary>
         /// <param name="name">The span representation of the enumeration name or underlying value to convert</param>
         /// <param name="value">When this method returns, contains an object of type 
-        /// <see cref="Something.Blah.ShortName" /> whose
+        /// <see cref="MyTestNameSpace.MyEnum" /> whose
         /// value is represented by <paramref name="value"/> if the parse operation succeeds.
         /// If the parse operation fails, contains the default value of the underlying type
-        /// of <see cref="Something.Blah.ShortName" />. This parameter is passed uninitialized.</param>
+        /// of <see cref="MyTestNameSpace.MyEnum" />. This parameter is passed uninitialized.</param>
         /// <param name="ignoreCase"><c>true</c> to read value in case insensitive mode; <c>false</c> to read value in case sensitive mode.</param>
         /// <returns><c>true</c> if the value parameter was converted successfully; otherwise, <c>false</c>.</returns>
         public static bool TryParse(
@@ -264,21 +274,21 @@ namespace Something.Blah
             [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
 #endif
             in ReadOnlySpan<char> name, 
-            out Something.Blah.ShortName value,
+            out MyTestNameSpace.MyEnum value,
             bool ignoreCase) 
             => TryParse(name, out value, ignoreCase, false);
 
         /// <summary>
         /// Converts the span representation of the name or numeric value of
-        /// an <see cref="Something.Blah.ShortName" /> to the equivalent instance.
+        /// an <see cref="MyTestNameSpace.MyEnum" /> to the equivalent instance.
         /// The return value indicates whether the conversion succeeded.
         /// </summary>
         /// <param name="name">The span representation of the enumeration name or underlying value to convert</param>
         /// <param name="result">When this method returns, contains an object of type 
-        /// <see cref="Something.Blah.ShortName" /> whose
+        /// <see cref="MyTestNameSpace.MyEnum" /> whose
         /// value is represented by <paramref name="result"/> if the parse operation succeeds.
         /// If the parse operation fails, contains the default value of the underlying type
-        /// of <see cref="Something.Blah.ShortName" />. This parameter is passed uninitialized.</param>
+        /// of <see cref="MyTestNameSpace.MyEnum" />. This parameter is passed uninitialized.</param>
         /// <param name="ignoreCase"><c>true</c> to read value in case insensitive mode; <c>false</c> to read value in case sensitive mode.</param>
         /// <param name="allowMatchingMetadataAttribute">If <c>true</c>, considers the value included in metadata attributes such as
         /// <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute"/> when parsing, otherwise only considers the member names.</param>
@@ -288,7 +298,7 @@ namespace Something.Blah
             [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
 #endif
             in ReadOnlySpan<char> name, 
-            out Something.Blah.ShortName result, 
+            out MyTestNameSpace.MyEnum result, 
             bool ignoreCase,             
             bool allowMatchingMetadataAttribute)
         {
@@ -296,14 +306,17 @@ namespace Something.Blah
             {
                 switch (name)
                 {
-                    case ReadOnlySpan<char> current when current.Equals(nameof(Something.Blah.ShortName.First).AsSpan(), System.StringComparison.OrdinalIgnoreCase):
-                        result = Something.Blah.ShortName.First;
+                    case ReadOnlySpan<char> current when current.Equals(nameof(MyTestNameSpace.MyEnum.First).AsSpan(), System.StringComparison.OrdinalIgnoreCase):
+                        result = MyTestNameSpace.MyEnum.First;
                         return true;
-                    case ReadOnlySpan<char> current when current.Equals(nameof(Something.Blah.ShortName.Second).AsSpan(), System.StringComparison.OrdinalIgnoreCase):
-                        result = Something.Blah.ShortName.Second;
+                    case ReadOnlySpan<char> current when current.Equals(nameof(MyTestNameSpace.MyEnum.Second).AsSpan(), System.StringComparison.OrdinalIgnoreCase):
+                        result = MyTestNameSpace.MyEnum.Second;
+                        return true;
+                    case ReadOnlySpan<char> current when current.Equals(nameof(MyTestNameSpace.MyEnum.Third).AsSpan(), System.StringComparison.OrdinalIgnoreCase):
+                        result = MyTestNameSpace.MyEnum.Third;
                         return true;
                     case ReadOnlySpan<char> current when int.TryParse(name, out var numericResult):
-                        result = (Something.Blah.ShortName)numericResult;
+                        result = (MyTestNameSpace.MyEnum)numericResult;
                         return true;
                     default:
                         result = default;
@@ -314,14 +327,17 @@ namespace Something.Blah
             {
                 switch (name)
                 {
-                    case ReadOnlySpan<char> current when current.Equals(nameof(Something.Blah.ShortName.First).AsSpan(), System.StringComparison.Ordinal):
-                        result = Something.Blah.ShortName.First;
+                    case ReadOnlySpan<char> current when current.Equals(nameof(MyTestNameSpace.MyEnum.First).AsSpan(), System.StringComparison.Ordinal):
+                        result = MyTestNameSpace.MyEnum.First;
                         return true;
-                    case ReadOnlySpan<char> current when current.Equals(nameof(Something.Blah.ShortName.Second).AsSpan(), System.StringComparison.Ordinal):
-                        result = Something.Blah.ShortName.Second;
+                    case ReadOnlySpan<char> current when current.Equals(nameof(MyTestNameSpace.MyEnum.Second).AsSpan(), System.StringComparison.Ordinal):
+                        result = MyTestNameSpace.MyEnum.Second;
+                        return true;
+                    case ReadOnlySpan<char> current when current.Equals(nameof(MyTestNameSpace.MyEnum.Third).AsSpan(), System.StringComparison.Ordinal):
+                        result = MyTestNameSpace.MyEnum.Third;
                         return true;
                     case ReadOnlySpan<char> current when int.TryParse(name, out var numericResult):
-                        result = (Something.Blah.ShortName)numericResult;
+                        result = (MyTestNameSpace.MyEnum)numericResult;
                         return true;
                     default:
                         result = default;
@@ -333,33 +349,35 @@ namespace Something.Blah
 
         /// <summary>
         /// Retrieves an array of the values of the members defined in
-        /// <see cref="Something.Blah.ShortName" />.
+        /// <see cref="MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
         /// should be cached if appropriate.
         /// </summary>
-        /// <returns>An array of the values defined in <see cref="Something.Blah.ShortName" /></returns>
-        public static Something.Blah.ShortName[] GetValues()
+        /// <returns>An array of the values defined in <see cref="MyTestNameSpace.MyEnum" /></returns>
+        public static MyTestNameSpace.MyEnum[] GetValues()
         {
             return new[]
             {
-                Something.Blah.ShortName.First,
-                Something.Blah.ShortName.Second,
+                MyTestNameSpace.MyEnum.First,
+                MyTestNameSpace.MyEnum.Second,
+                MyTestNameSpace.MyEnum.Third,
             };
         }
 
         /// <summary>
         /// Retrieves an array of the names of the members defined in
-        /// <see cref="Something.Blah.ShortName" />.
+        /// <see cref="MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
         /// should be cached if appropriate.
         /// </summary>
-        /// <returns>An array of the names of the members defined in <see cref="Something.Blah.ShortName" /></returns>
+        /// <returns>An array of the names of the members defined in <see cref="MyTestNameSpace.MyEnum" /></returns>
         public static string[] GetNames()
         {
             return new[]
             {
-                nameof(Something.Blah.ShortName.First),
-                nameof(Something.Blah.ShortName.Second),
+                nameof(MyTestNameSpace.MyEnum.First),
+                nameof(MyTestNameSpace.MyEnum.Second),
+                nameof(MyTestNameSpace.MyEnum.Third),
             };
         }
     }


### PR DESCRIPTION
Embarrassingly, this never worked. This fixes the implementation, renames the method so that it doesn't conflict with the existing `Enum.HasFlags` method, and fixes detection

Closes #25