### PR TITLE
Fix macos build

### DIFF
--- a/.github/workflows/BuildAndPack.yml
+++ b/.github/workflows/BuildAndPack.yml
@@ -99,8 +99,8 @@ jobs:
           name: artifacts
           path: artifacts
   macOS-latest:
-    name: macOS-latest
-    runs-on: macOS-latest
+    name: macos-13 # latest is arm64, and it breaks a bunch of stuff
+    runs-on: macos-13 # latest is arm64, and it breaks a bunch of stuff
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3


### PR DESCRIPTION
They switched `macos-latest` from being x64 to arm64, and it broke stuff

https://github.com/actions/runner-images/issues/9741