### PR TITLE
Fix EquatableArray.Equals override to avoid an endless recursion with a stackoverflow exception

### DIFF
--- a/src/NetEscapades.EnumGenerators/EquatableArray.cs
+++ b/src/NetEscapades.EnumGenerators/EquatableArray.cs
@@ -34,7 +34,7 @@ public readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnume
     /// <sinheritdoc/>
     public override bool Equals(object? obj)
     {
-        return obj is EquatableArray<T> array && Equals(this, array);
+        return obj is EquatableArray<T> array && Equals(array);
     }
 
     /// <sinheritdoc/>

--- a/tests/NetEscapades.EnumGenerators.Tests/EquatableArrayTests.cs
+++ b/tests/NetEscapades.EnumGenerators.Tests/EquatableArrayTests.cs
@@ -1,0 +1,13 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace NetEscapades.EnumGenerators.Tests;
+public class EquatableArrayTests {
+    [Fact]
+    public void ObjectEqualsWorksAsExpected() {
+        var instances = new EquatableArray<string>(["A"]);
+        object comparand = new EquatableArray<string>(["A"]);
+
+        instances.Equals(comparand).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Fixes an error in `EquatableArray.Equals(object?)` which currently ends in an `StackOverflowException` due to an endless recursion.