### PR TITLE
Testing fixes

### DIFF
--- a/src/NetEscapades.EnumGenerators/EnumGenerator.cs
+++ b/src/NetEscapades.EnumGenerators/EnumGenerator.cs
@@ -123,9 +123,9 @@ public class EnumGenerator : IIncrementalGenerator
             static (spc, toIntercept) => ExecuteInterceptors(toIntercept, spc));
 #else
         context.RegisterSourceOutput(interceptableEnumsAndLocations,
-            static (spc, enumAndlocation) =>
+            static (spc, enumAndLocation) =>
             {
-                spc.ReportDiagnostic(Diagnostic.Create(DiagnosticHelper.SdkVersionTooLow, location: enumAndlocation.location.ToLocation()));
+                spc.ReportDiagnostic(Diagnostic.Create(DiagnosticHelper.SdkVersionTooLow, location: enumAndLocation.location?.ToLocation()));
             });
 #endif
         context.RegisterImplementationSourceOutput(settings,

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,6 +5,7 @@
     <NuGetAudit>false</NuGetAudit>
     <ArtifactsPath>$(MSBuildThisFileDirectory)../artifacts</ArtifactsPath>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <NoWarn>NU1901;NU1902;NU1903;NU1904</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <!-- Ignore 2.1.0 advisories -->

--- a/tests/NetEscapades.EnumGenerators.Tests/EnumGeneratorTests.cs
+++ b/tests/NetEscapades.EnumGenerators.Tests/EnumGeneratorTests.cs
@@ -186,7 +186,7 @@ namespace MyTestNameSpace
                 [Description("4th")]
                 Fourth = 3
             }
-        }"
+        }
         """;
 
         var (diagnostics, output) = TestHelpers.GetGeneratedOutput<EnumGenerator>(new(input));
@@ -222,7 +222,7 @@ namespace MyTestNameSpace
                 [Description("Number 4")]
                 Fourth = 3
             }
-        }"
+        }
         """;
 
         var (diagnostics, output) = TestHelpers.GetGeneratedOutput<EnumGenerator>(new(input));
@@ -297,7 +297,6 @@ namespace MyTestNameSpace
     public Task CanHandleNamespaceAndClassNameAreTheSame()
     {
         const string input = @"using NetEscapades.EnumGenerators;
-using System.ComponentModel.DataAnnotations;
 
 namespace Foo
 {
@@ -321,18 +320,18 @@ namespace Foo
         const string input =
             """"
             using NetEscapades.EnumGenerators;
-            using System.ComponentModel.DataAnnotations;
+            using System.ComponentModel;
 
             namespace Test;
 
             [EnumExtensions]
             public enum StringTesting
             {
-               [System.ComponentModel.Description("Quotes \"")]   Quotes,
-               [System.ComponentModel.Description(@"Literal Quotes """)]   LiteralQuotes,
-               [System.ComponentModel.Description("Backslash \\")]   Backslash,
-               [System.ComponentModel.Description(@"LiteralBackslash \")]   BackslashLiteral,
-               [System.ComponentModel.Description("New\nLine")]   NewLine,
+               [Description("Quotes \"")]   Quotes,
+               [Description(@"Literal Quotes """)]   LiteralQuotes,
+               [Description("Backslash \\")]   Backslash,
+               [Description(@"LiteralBackslash \")]   BackslashLiteral,
+               [Description("New\nLine")]   NewLine,
             }
             """";
 
@@ -427,5 +426,4 @@ namespace Foo
         Assert.Empty(diagnostics);
         return Verifier.Verify(output).ScrubExpectedChanges().UseDirectory("Snapshots");
     }
-
 }

--- a/tests/NetEscapades.EnumGenerators.Tests/InterceptorTests.cs
+++ b/tests/NetEscapades.EnumGenerators.Tests/InterceptorTests.cs
@@ -16,9 +16,15 @@ namespace NetEscapades.EnumGenerators.Tests.Roslyn4_04;
 [UsesVerify]
 public class InterceptorTests
 {
-    private readonly Dictionary<string, string> _interceptionEnabled =
+    private readonly Dictionary<string, string> _analyzerOpts =
         new() { { "build_property.EnableEnumGeneratorInterceptor", "true" } };
 
+    private readonly Dictionary<string, string> _features =
+        new()
+        {
+            { "InterceptorsPreviewNamespaces", "NetEscapades.EnumGenerators" },
+            { "InterceptorsNamespaces", "NetEscapades.EnumGenerators" },
+        };
 #if INTERCEPTORS
     [Fact]
     public Task CanInterceptToString()
@@ -36,7 +42,7 @@ public class InterceptorTests
                     Second = 1,
                 }
                 
-                public class InnerClass
+                internal class InnerClass
                 {
                     public MyEnum _field = default;
                     public MyEnum Property {get;set;} = default;
@@ -52,7 +58,7 @@ public class InterceptorTests
             }
             """;
         var (diagnostics, output) =
-            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_interceptionEnabled, input));
+            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_analyzerOpts, _features, input));
 
         Assert.Empty(diagnostics);
         return Verifier.Verify(output).ScrubExpectedChanges().UseDirectory("Snapshots");
@@ -77,7 +83,7 @@ public class InterceptorTests
                     Third = 4,
                 }
                 
-                public class InnerClass
+                internal class InnerClass
                 {
                     public MyEnum _field = default;
                     public MyEnum Property {get;set;} = default;
@@ -93,7 +99,7 @@ public class InterceptorTests
             }
             """;
         var (diagnostics, output) =
-            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_interceptionEnabled, input));
+            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_analyzerOpts, _features, input));
 
         Assert.Empty(diagnostics);
         return Verifier.Verify(output).ScrubExpectedChanges().UseDirectory("Snapshots");
@@ -136,23 +142,23 @@ public class InterceptorTests
                     public void MyTest()
                     {
                         var result = AnotherEnum.First.ToString();
-                        AssertValue(MyEnum.First);
-                        AssertValue(AnotherEnum.Second);
-                        AssertValue(MyEnum.Third);
+                        AssertValue1(MyEnum.First);
+                        AssertValue2(AnotherEnum.Second);
+                        AssertValue1(MyEnum.Third);
                         var result2 = YetAnotherEnum.First.ToString();
-                        AssertValue(YetAnotherEnum.Second);
+                        AssertValue3(YetAnotherEnum.Second);
                         
-                        void AssertValue(MyEnum value)
+                        void AssertValue1(MyEnum value)
                         {
                             var toString = value.ToString();
                         }
 
-                        void AssertValue(AnotherEnum value)
+                        void AssertValue2(AnotherEnum value)
                         {
                             var toString = value.ToString();
                         }
 
-                        void AssertValue(YetAnotherEnum value)
+                        void AssertValue3(YetAnotherEnum value)
                         {
                             var toString = value.ToString();
                         }
@@ -161,7 +167,7 @@ public class InterceptorTests
             }
             """;
         var (diagnostics, output) = 
-            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_interceptionEnabled, input));
+            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_analyzerOpts, _features, input));
 
         Assert.Empty(diagnostics);
         return Verifier.Verify(output).ScrubExpectedChanges().UseDirectory("Snapshots");
@@ -173,6 +179,7 @@ public class InterceptorTests
         const string input =
             """
             using NetEscapades.EnumGenerators;
+            using System;
 
             namespace MyTestNameSpace
             {
@@ -200,30 +207,30 @@ public class InterceptorTests
                     Third = 2,
                 }
                 
-                public class InnerClass
+                internal class InnerClass
                 {
                     public void MyTest()
                     {
                         var result = AnotherEnum.First.ToString();
-                        AssertValue(MyEnum.First);
-                        AssertValue(AnotherEnum.Second);
-                        AssertValue(MyEnum.Third);
+                        AssertValue1(MyEnum.First);
+                        AssertValue2(AnotherEnum.Second);
+                        AssertValue1(MyEnum.Third);
                         var result2 = YetAnotherEnum.First.ToString();
-                        AssertValue(YetAnotherEnum.Second);
+                        AssertValue3(YetAnotherEnum.Second);
                         
                         var hasValue = AnotherEnum.Second.HasFlag(AnotherEnum.First);
                         
-                        void AssertValue(MyEnum value)
+                        void AssertValue1(MyEnum value)
                         {
                             var toString = value.ToString();
                         }
 
-                        void AssertValue(AnotherEnum value)
+                        void AssertValue2(AnotherEnum value)
                         {
                             var toString = value.ToString();
                         }
 
-                        void AssertValue(YetAnotherEnum value)
+                        void AssertValue3(YetAnotherEnum value)
                         {
                             var toString = value.ToString();
                         }
@@ -232,7 +239,7 @@ public class InterceptorTests
             }
             """;
         var (diagnostics, output) = 
-            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_interceptionEnabled, input));
+            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_analyzerOpts, _features, input));
 
         Assert.Empty(diagnostics);
         return Verifier.Verify(output).ScrubExpectedChanges().UseDirectory("Snapshots");
@@ -272,7 +279,7 @@ public class InterceptorTests
             }
             """;
         var (diagnostics, output) = 
-            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_interceptionEnabled, input));
+            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_analyzerOpts, _features, input));
 
         Assert.Empty(diagnostics);
         return Verifier.Verify(output).ScrubExpectedChanges().UseDirectory("Snapshots");
@@ -314,7 +321,7 @@ public class InterceptorTests
             }
             """;
         var (diagnostics, output) = 
-            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_interceptionEnabled, input));
+            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_analyzerOpts, _features, input));
 
         Assert.Empty(diagnostics);
         return Verifier.Verify(output).ScrubExpectedChanges().UseDirectory("Snapshots");
@@ -357,7 +364,7 @@ public class InterceptorTests
             }
             """;
         var (diagnostics, output) = 
-            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_interceptionEnabled, input));
+            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_analyzerOpts, _features, input));
 
         Assert.Empty(diagnostics);
         return Verifier.Verify(output).ScrubExpectedChanges().UseDirectory("Snapshots");
@@ -379,7 +386,7 @@ public class InterceptorTests
                     Second = 1,
                 }
                 
-                public class InnerClass
+                internal class InnerClass
                 {
                     public MyEnum _field = default;
                     public MyEnum Property {get;set;} = default;
@@ -394,7 +401,7 @@ public class InterceptorTests
                 }
             }
             """;
-        var opts = new TestHelpers.Options(LanguageVersion.CSharp11, _interceptionEnabled, input);
+        var opts = new TestHelpers.Options(LanguageVersion.CSharp11, _analyzerOpts, _features, input);
         var (diagnostics, output) =
             TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(opts);
 
@@ -418,7 +425,7 @@ public class InterceptorTests
                     Second = 1,
                 }
                 
-                public class InnerClass
+                internal class InnerClass
                 {
                     public MyEnum _field = default;
                     public MyEnum Property {get;set;} = default;
@@ -456,7 +463,7 @@ public class InterceptorTests
                     Second = 1,
                 }
                 
-                public class InnerClass
+                internal class InnerClass
                 {
                     public MyEnum _field = default;
                     public MyEnum Property {get;set;} = default;
@@ -471,7 +478,7 @@ public class InterceptorTests
                 }
             }
             """;
-        var opts = new TestHelpers.Options(LanguageVersion.CSharp10, _interceptionEnabled, input);
+        var opts = new TestHelpers.Options(LanguageVersion.CSharp10, _analyzerOpts, _features, input);
         var (diagnostics, output) =
             TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(opts);
 
@@ -512,7 +519,7 @@ public class InterceptorTests
             }
             """;
         var (diagnostics, output) =
-            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_interceptionEnabled, input));
+            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_analyzerOpts, _features, input));
 
         diagnostics.Should().ContainSingle(x => x.Id == DiagnosticHelper.SdkVersionTooLow.Id);
         return Verifier.Verify(output).ScrubExpectedChanges().UseDirectory("Snapshots");
@@ -554,7 +561,7 @@ public class InterceptorTests
             }
             """;
         var (diagnostics, output) = 
-            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_interceptionEnabled, input));
+            TestHelpers.GetGeneratedTrees<EnumGenerator, TrackingNames>(new(_analyzerOpts, _features, input));
 
         diagnostics.Should()
             .OnlyContain(x => x.Id == DiagnosticHelper.SdkVersionTooLow.Id)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptEnumMarkedAsNotInterceptable.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptEnumMarkedAsNotInterceptable.verified.txt
@@ -676,6 +676,18 @@ namespace MyTestNameSpace
             };
 
         /// <summary>
+        /// Determines whether one or more bit fields are set in the current instance.
+        /// Equivalent to calling <see cref="global::System.Enum.HasFlag" /> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value of the instance to investigate</param>
+        /// <param name="flag">The flag to check for</param>
+        /// <returns><c>true</c> if the fields set in the flag are also set in the current instance; otherwise <c>false</c>.</returns>
+        /// <remarks>If the underlying value of <paramref name="flag"/> is zero, the method returns true.
+        /// This is consistent with the behaviour of <see cref="global::System.Enum.HasFlag" /></remarks>
+        public static bool HasFlagFast(this global::MyTestNameSpace.AnotherEnum value, global::MyTestNameSpace.AnotherEnum flag)
+            => flag == 0 ? true : (value & flag) == flag;
+
+        /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.
         /// </summary>
         /// <param name="value">The value to check if it's defined</param>
@@ -1170,12 +1182,12 @@ namespace NetEscapades.EnumGenerators
 {
     static file class EnumInterceptors
     {
-        [global::System.Runtime.CompilerServices.InterceptsLocation(123, "REDACTED")] // Program.cs(33,44)
-        [global::System.Runtime.CompilerServices.InterceptsLocation(123, "REDACTED")] // Program.cs(49,38)
+        [global::System.Runtime.CompilerServices.InterceptsLocation(123, "REDACTED")] // Program.cs(34,44)
+        [global::System.Runtime.CompilerServices.InterceptsLocation(123, "REDACTED")] // Program.cs(50,38)
         public static string AnotherEnumExtensionsToString(this global::System.Enum value)
             => global::MyTestNameSpace.AnotherEnumExtensions.ToStringFast((global::MyTestNameSpace.AnotherEnum)value);
 
-        [global::System.Runtime.CompilerServices.InterceptsLocation(123, "REDACTED")] // Program.cs(40,47)
+        [global::System.Runtime.CompilerServices.InterceptsLocation(123, "REDACTED")] // Program.cs(41,47)
         public static bool AnotherEnumExtensionsHasFlag(this global::System.Enum value, global::System.Enum flag)
             => global::MyTestNameSpace.AnotherEnumExtensions.HasFlagFast((global::MyTestNameSpace.AnotherEnum)value, (global::MyTestNameSpace.AnotherEnum)flag);
 


### PR DESCRIPTION
- Fix null ref warning in generator
- Stop the tests complaining about .NET Core 2.1 once and for all
- Ensure we include all compilation errors (not just generator diagnostics)