### PR TITLE
Breaking change: `ToStringFast` mimics `ToString` by default

### DIFF
--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInFooExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInFooExtensionsTests.cs
@@ -45,6 +45,7 @@ public class EnumInFooExtensionsTests : ExtensionTests<EnumInFoo>
     };
 
     protected override string ToStringFast(EnumInFoo value) => value.ToStringFast();
+    protected override string ToStringFast(EnumInFoo value, bool withMetadata) => value.ToStringFast(withMetadata);
     protected override bool IsDefined(EnumInFoo value) => EnumInFooExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => EnumInFooExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
 #if READONLYSPAN
@@ -67,6 +68,10 @@ public class EnumInFooExtensionsTests : ExtensionTests<EnumInFoo>
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(EnumInFoo value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastWithMetadata(EnumInFoo value) => GeneratesToStringFastWithMetadataTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInNamespaceExtensionsTests.cs
@@ -44,6 +44,7 @@ public class EnumInNamespaceExtensionsTests : ExtensionTests<EnumInNamespace>
     };
 
     protected override string ToStringFast(EnumInNamespace value) => value.ToStringFast();
+    protected override string ToStringFast(EnumInNamespace value, bool withMetadata) => value.ToStringFast(withMetadata);
     protected override bool IsDefined(EnumInNamespace value) => EnumInNamespaceExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => EnumInNamespaceExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
 #if READONLYSPAN
@@ -66,6 +67,10 @@ public class EnumInNamespaceExtensionsTests : ExtensionTests<EnumInNamespace>
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(EnumInNamespace value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastWithMetadata(EnumInNamespace value) => GeneratesToStringFastWithMetadataTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDescriptionInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDescriptionInNamespaceExtensionsTests.cs
@@ -44,6 +44,7 @@ public class EnumWithDescriptionInNamespaceExtensionsTests : ExtensionTests<Enum
     };
 
     protected override string ToStringFast(EnumWithDescriptionInNamespace value) => value.ToStringFast();
+    protected override string ToStringFast(EnumWithDescriptionInNamespace value, bool withMetadata) => value.ToStringFast(withMetadata);
     protected override bool IsDefined(EnumWithDescriptionInNamespace value) => EnumWithDescriptionInNamespaceExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => EnumWithDescriptionInNamespaceExtensions.IsDefined(name, allowMatchingMetadataAttribute);
 #if READONLYSPAN
@@ -65,6 +66,10 @@ public class EnumWithDescriptionInNamespaceExtensionsTests : ExtensionTests<Enum
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(EnumWithDescriptionInNamespace value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastWithMetadata(EnumWithDescriptionInNamespace value) => GeneratesToStringFastWithMetadataTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDisplayNameInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDisplayNameInNamespaceExtensionsTests.cs
@@ -44,6 +44,7 @@ public class EnumWithDisplayNameInNamespaceExtensionsTests : ExtensionTests<Enum
     };
 
     protected override string ToStringFast(EnumWithDisplayNameInNamespace value) => value.ToStringFast();
+    protected override string ToStringFast(EnumWithDisplayNameInNamespace value, bool withMetadata) => value.ToStringFast(withMetadata);
     protected override bool IsDefined(EnumWithDisplayNameInNamespace value) => EnumWithDisplayNameInNamespaceExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => EnumWithDisplayNameInNamespaceExtensions.IsDefined(name, allowMatchingMetadataAttribute);
 #if READONLYSPAN
@@ -64,6 +65,10 @@ public class EnumWithDisplayNameInNamespaceExtensionsTests : ExtensionTests<Enum
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(EnumWithDisplayNameInNamespace value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastWithMetadata(EnumWithDisplayNameInNamespace value) => GeneratesToStringFastWithMetadataTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithSameDisplayNameExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithSameDisplayNameExtensionsTests.cs
@@ -44,6 +44,7 @@ public class EnumWithSameDisplayNameExtensionsTests : ExtensionTests<EnumWithSam
     };
 
     protected override string ToStringFast(EnumWithSameDisplayName value) => value.ToStringFast();
+    protected override string ToStringFast(EnumWithSameDisplayName value, bool withMetadata) => value.ToStringFast(withMetadata);
     protected override bool IsDefined(EnumWithSameDisplayName value) => EnumWithSameDisplayNameExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => EnumWithSameDisplayNameExtensions.IsDefined(name, allowMatchingMetadataAttribute);
 #if READONLYSPAN
@@ -64,6 +65,10 @@ public class EnumWithSameDisplayNameExtensionsTests : ExtensionTests<EnumWithSam
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(EnumWithSameDisplayName value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastWithMetadata(EnumWithSameDisplayName value) => GeneratesToStringFastWithMetadataTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/ExtensionTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/ExtensionTests.cs
@@ -25,6 +25,7 @@ namespace NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests;
 public abstract class ExtensionTests<T> where T : struct
 {
     protected abstract string ToStringFast(T value);
+    protected abstract string ToStringFast(T value, bool withMetadata);
     protected abstract bool IsDefined(T value);
     protected abstract bool IsDefined(string name, bool allowMatchingMetadataAttribute = false);
 #if READONLYSPAN
@@ -43,6 +44,17 @@ public abstract class ExtensionTests<T> where T : struct
     protected void GeneratesToStringFastTest(T value)
     {
         var serialized = ToStringFast(value);
+        var expectedValue = value.ToString();
+
+        serialized.Should().Be(expectedValue);
+
+        var serializedAltPath = ToStringFast(value, withMetadata: false);
+        serializedAltPath.Should().Be(expectedValue);
+    }
+
+    protected void GeneratesToStringFastWithMetadataTest(T value)
+    {
+        var serialized = ToStringFast(value, withMetadata: true);
         var valueAsString = value.ToString();
 
         TryGetDisplayNameOrDescription(valueAsString, out var displayName);

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/ExternalEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/ExternalEnumExtensionsTests.cs
@@ -47,6 +47,7 @@ public class ExternalEnumExtensionsTests : ExtensionTests<DateTimeKind>
     };
 
     protected override string ToStringFast(DateTimeKind value) => value.ToStringFast();
+    protected override string ToStringFast(DateTimeKind value, bool withMetadata) => value.ToStringFast(withMetadata);
     protected override bool IsDefined(DateTimeKind value) => DateTimeKindExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => DateTimeKindExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
 #if READONLYSPAN
@@ -67,6 +68,10 @@ public class ExternalEnumExtensionsTests : ExtensionTests<DateTimeKind>
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(DateTimeKind value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastWithMetadata(DateTimeKind value) => GeneratesToStringFastWithMetadataTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/ExternalFlagsEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/ExternalFlagsEnumExtensionsTests.cs
@@ -49,6 +49,7 @@ public class ExternalFileShareExtensionsTests : ExtensionTests<FileShare>
     };
 
     protected override string ToStringFast(FileShare value) => value.ToStringFast();
+    protected override string ToStringFast(FileShare value, bool withMetadata) => value.ToStringFast(withMetadata);
     protected override bool IsDefined(FileShare value) => FileShareExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => FileShareExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
 #if READONLYSPAN
@@ -75,6 +76,10 @@ public class ExternalFileShareExtensionsTests : ExtensionTests<FileShare>
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(FileShare value) => GeneratesToStringFastTest(value);
+ 
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastWithMetadata(FileShare value) => GeneratesToStringFastWithMetadataTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/FlagsEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/FlagsEnumExtensionsTests.cs
@@ -48,6 +48,7 @@ public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum>
     };
 
     protected override string ToStringFast(FlagsEnum value) => value.ToStringFast();
+    protected override string ToStringFast(FlagsEnum value, bool withMetadata) => value.ToStringFast(withMetadata);
     protected override bool IsDefined(FlagsEnum value) => FlagsEnumExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => FlagsEnumExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
 #if READONLYSPAN
@@ -75,6 +76,10 @@ public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum>
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(FlagsEnum value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastWithMetadata(FlagsEnum value) => GeneratesToStringFastWithMetadataTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/LongEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/LongEnumExtensionsTests.cs
@@ -44,6 +44,7 @@ public class LongEnumExtensionsTests : ExtensionTests<LongEnum>
     };
 
     protected override string ToStringFast(LongEnum value) => value.ToStringFast();
+    protected override string ToStringFast(LongEnum value, bool withMetadata) => value.ToStringFast(withMetadata);
     protected override bool IsDefined(LongEnum value) => LongEnumExtensions.IsDefined(value);
     protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => LongEnumExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
 #if READONLYSPAN
@@ -65,6 +66,10 @@ public class LongEnumExtensionsTests : ExtensionTests<LongEnum>
     [Theory]
     [MemberData(nameof(ValidEnumValues))]
     public void GeneratesToStringFast(LongEnum value) => GeneratesToStringFastTest(value);
+
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesToStringFastWithMetadata(LongEnum value) => GeneratesToStringFastWithMetadataTest(value);
 
     [Theory]
     [MemberData(nameof(ValidEnumValues))]

--- a/tests/NetEscapades.EnumGenerators.Interceptors.IntegrationTests/InterceptorTests.cs
+++ b/tests/NetEscapades.EnumGenerators.Interceptors.IntegrationTests/InterceptorTests.cs
@@ -143,7 +143,7 @@ public class InterceptorTests
 #if INTERCEPTORS
     [Fact(Skip = "Interceptors are supported in this SDK")]
 #else
-    [Fact]
+    [Fact(Skip = "Can't actually verify it's not interceptable")]
 #endif
     public void CallingToStringIsNotInterceptedWhenNotSupportedBySdk()
     {

--- a/tests/NetEscapades.EnumGenerators.Interceptors.IntegrationTests/InterceptorTests.cs
+++ b/tests/NetEscapades.EnumGenerators.Interceptors.IntegrationTests/InterceptorTests.cs
@@ -36,17 +36,14 @@ public class InterceptorTests
 #endif
     public void CallingToStringIsIntercepted()
     {
-        var result1 = EnumWithDisplayNameInNamespace.Second.ToString();
-        var result2 = EnumWithDisplayNameInNamespace.Second.ToStringFast();
-        Assert.Equal(result1, result2);
-
         AssertValue(EnumWithDisplayNameInNamespace.First);
         AssertValue(EnumWithDisplayNameInNamespace.Second);
         AssertValue(EnumWithDisplayNameInNamespace.Third);
 
         void AssertValue(EnumWithDisplayNameInNamespace value)
         {
-            // These return different values when interception is not enabled
+            // This doesn't _actually_ test interception, because can't
+            // differentiate with built-in version, it's only really verifying the generated code compiles 
             var toString = value.ToString();
             var fast = value.ToStringFast();
             Assert.Equal(fast, toString);
@@ -74,6 +71,8 @@ public class InterceptorTests
 #endif
     public void CallingToStringIsIntercepted_EnumInFoo()
     {
+        // This doesn't _actually_ test interception, because can't
+        // differentiate with built-in version, it's only really verifying the generated code compiles 
         var result1 = EnumInFoo.Second.ToString();
         var result2 = EnumInFoo.Second.ToStringFast();
         Assert.Equal(result1, result2);
@@ -86,6 +85,8 @@ public class InterceptorTests
 #endif
     public void CallingToStringIsIntercepted_EnumWithExtensionInOtherNamespace()
     {
+        // This doesn't _actually_ test interception, because can't
+        // differentiate with built-in version, it's only really verifying the generated code compiles 
         var result1 = EnumWithExtensionInOtherNamespace.Second.ToString();
         var result2 = SomethingElse.SomeExtension.ToStringFast(EnumWithExtensionInOtherNamespace.Second);
         Assert.Equal(result1, result2);
@@ -131,7 +132,7 @@ public class InterceptorTests
         Assert.False(FileShare.Read.HasFlag(combined));
     }
 
-    [Fact]
+    [Fact(Skip = "Can't actually verify it's not interceptable")]
     public void CallingNonInterceptableEnumIsNotIntercepted()
     {
         var result1 = NonInterceptableEnum.Second.ToString();

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsForFlagsEnum_Params.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsForFlagsEnum_Params.verified.txt
@@ -30,12 +30,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -44,6 +56,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Third => nameof(global::MyTestNameSpace.MyEnum.Third),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Determines whether one or more bit fields are set in the current instance.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInChildNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInChildNamespace.verified.txt
@@ -30,12 +30,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -43,6 +55,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInGlobalNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInGlobalNamespace.verified.txt
@@ -28,12 +28,24 @@ using System;
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyEnum value)
             => value switch
             {
@@ -41,6 +53,9 @@ using System;
                 global::MyEnum.Second => nameof(global::MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInNestedClass.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInNestedClass.verified.txt
@@ -30,12 +30,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.InnerClass.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.InnerClass.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.InnerClass.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.InnerClass.MyEnum value)
             => value switch
             {
@@ -43,6 +55,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.InnerClass.MyEnum.Second => nameof(global::MyTestNameSpace.InnerClass.MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.InnerClass.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomName.verified.txt
@@ -30,12 +30,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -43,6 +55,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNames.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNames.verified.txt
@@ -30,13 +30,35 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
+            => value switch
+            {
+                global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
+                global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
+                global::MyTestNameSpace.MyEnum.Third => nameof(global::MyTestNameSpace.MyEnum.Third),
+                global::MyTestNameSpace.MyEnum.Fourth => nameof(global::MyTestNameSpace.MyEnum.Fourth),
+                _ => value.ToString(),
+            };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespace.verified.txt
@@ -30,12 +30,24 @@ namespace A.B
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -43,6 +55,9 @@ namespace A.B
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespaceAndName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespaceAndName.verified.txt
@@ -30,12 +30,24 @@ namespace A.B
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -43,6 +55,9 @@ namespace A.B
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithSameDisplayName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithSameDisplayName.verified.txt
@@ -30,13 +30,35 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
+            => value switch
+            {
+                global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
+                global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
+                global::MyTestNameSpace.MyEnum.Third => nameof(global::MyTestNameSpace.MyEnum.Third),
+                global::MyTestNameSpace.MyEnum.Fourth => nameof(global::MyTestNameSpace.MyEnum.Fourth),
+                _ => value.ToString(),
+            };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomName.verified.txt
@@ -30,12 +30,24 @@ namespace System
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::System.DateTimeKind"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::System.DateTimeKind value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::System.DateTimeKind"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::System.DateTimeKind value)
             => value switch
             {
@@ -44,6 +56,9 @@ namespace System
                 global::System.DateTimeKind.Local => nameof(global::System.DateTimeKind.Local),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::System.DateTimeKind value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomNamespace.verified.txt
@@ -30,12 +30,24 @@ namespace A.B
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::System.DateTimeKind"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::System.DateTimeKind value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::System.DateTimeKind"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::System.DateTimeKind value)
             => value switch
             {
@@ -44,6 +56,9 @@ namespace A.B
                 global::System.DateTimeKind.Local => nameof(global::System.DateTimeKind.Local),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::System.DateTimeKind value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomNamespaceAndName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomNamespaceAndName.verified.txt
@@ -30,12 +30,24 @@ namespace A.B
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::System.DateTimeKind"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::System.DateTimeKind value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::System.DateTimeKind"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::System.DateTimeKind value)
             => value switch
             {
@@ -44,6 +56,9 @@ namespace A.B
                 global::System.DateTimeKind.Local => nameof(global::System.DateTimeKind.Local),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::System.DateTimeKind value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForExternalEnum.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForExternalEnum.verified.txt
@@ -30,12 +30,24 @@ namespace System
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::System.StringComparison"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::System.StringComparison value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::System.StringComparison"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::System.StringComparison value)
             => value switch
             {
@@ -47,6 +59,9 @@ namespace System
                 global::System.StringComparison.OrdinalIgnoreCase => nameof(global::System.StringComparison.OrdinalIgnoreCase),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::System.StringComparison value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForExternalFlagsEnum.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForExternalFlagsEnum.verified.txt
@@ -30,12 +30,24 @@ namespace System.IO
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::System.IO.FileShare"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::System.IO.FileShare value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::System.IO.FileShare"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::System.IO.FileShare value)
             => value switch
             {
@@ -47,6 +59,9 @@ namespace System.IO
                 global::System.IO.FileShare.Inheritable => nameof(global::System.IO.FileShare.Inheritable),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::System.IO.FileShare value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Determines whether one or more bit fields are set in the current instance.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForMultipleExternalEnums.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForMultipleExternalEnums.verified.txt
@@ -31,12 +31,24 @@ namespace System
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::System.ConsoleColor"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::System.ConsoleColor value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::System.ConsoleColor"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::System.ConsoleColor value)
             => value switch
             {
@@ -58,6 +70,9 @@ namespace System
                 global::System.ConsoleColor.White => nameof(global::System.ConsoleColor.White),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::System.ConsoleColor value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.
@@ -779,12 +794,24 @@ namespace System
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::System.DateTimeKind"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::System.DateTimeKind value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::System.DateTimeKind"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::System.DateTimeKind value)
             => value switch
             {
@@ -793,6 +820,9 @@ namespace System
                 global::System.DateTimeKind.Local => nameof(global::System.DateTimeKind.Local),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::System.DateTimeKind value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanHandleNamespaceAndClassNameAreTheSame.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanHandleNamespaceAndClassNameAreTheSame.verified.txt
@@ -30,18 +30,33 @@ namespace Foo
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::Foo.TestEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::Foo.TestEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::Foo.TestEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::Foo.TestEnum value)
             => value switch
             {
                 global::Foo.TestEnum.Value1 => nameof(global::Foo.TestEnum.Value1),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::Foo.TestEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteEnums_CS0612_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteEnums_CS0612_Issue97.verified.txt
@@ -28,12 +28,24 @@ using System;
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyEnum value)
             => value switch
             {
@@ -41,6 +53,9 @@ using System;
                 global::MyEnum.Second => nameof(global::MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteEnums_CS0618_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteEnums_CS0618_Issue97.verified.txt
@@ -28,12 +28,24 @@ using System;
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyEnum value)
             => value switch
             {
@@ -41,6 +53,9 @@ using System;
                 global::MyEnum.Second => nameof(global::MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteMembers_CS0612_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteMembers_CS0612_Issue97.verified.txt
@@ -28,12 +28,24 @@ using System;
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyEnum value)
             => value switch
             {
@@ -41,6 +53,9 @@ using System;
                 global::MyEnum.Second => nameof(global::MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteMembers_CS0618_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteMembers_CS0618_Issue97.verified.txt
@@ -28,12 +28,24 @@ using System;
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyEnum value)
             => value switch
             {
@@ -41,6 +53,9 @@ using System;
                 global::MyEnum.Second => nameof(global::MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.HandlesStringsWithQuotesAndSlashesInDescription.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.HandlesStringsWithQuotesAndSlashesInDescription.verified.txt
@@ -30,13 +30,36 @@ namespace Test
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::Test.StringTesting"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::Test.StringTesting value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::Test.StringTesting"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::Test.StringTesting value)
+            => value switch
+            {
+                global::Test.StringTesting.Quotes => nameof(global::Test.StringTesting.Quotes),
+                global::Test.StringTesting.LiteralQuotes => nameof(global::Test.StringTesting.LiteralQuotes),
+                global::Test.StringTesting.Backslash => nameof(global::Test.StringTesting.Backslash),
+                global::Test.StringTesting.BackslashLiteral => nameof(global::Test.StringTesting.BackslashLiteral),
+                global::Test.StringTesting.NewLine => nameof(global::Test.StringTesting.NewLine),
+                _ => value.ToString(),
+            };
+
+        private static string ToStringFastWithMetadata(this global::Test.StringTesting value)
             => value switch
             {
                 global::Test.StringTesting.Quotes => "Quotes \"",

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanHandleEnumsWithSameNameInDifferentNamespaces.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanHandleEnumsWithSameNameInDifferentNamespaces.verified.txt
@@ -152,12 +152,24 @@ namespace Foo
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::Foo.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::Foo.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::Foo.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::Foo.MyEnum value)
             => value switch
             {
@@ -166,6 +178,9 @@ namespace Foo
                 global::Foo.MyEnum.Third => nameof(global::Foo.MyEnum.Third),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::Foo.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Determines whether one or more bit fields are set in the current instance.
@@ -678,12 +693,24 @@ namespace Bar
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::Bar.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::Bar.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::Bar.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::Bar.MyEnum value)
             => value switch
             {
@@ -692,6 +719,9 @@ namespace Bar
                 global::Bar.MyEnum.Third => nameof(global::Bar.MyEnum.Third),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::Bar.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Determines whether one or more bit fields are set in the current instance.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptEnumInDifferentNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptEnumInDifferentNamespace.verified.txt
@@ -152,12 +152,24 @@ namespace Bar
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::Foo.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::Foo.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::Foo.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::Foo.MyEnum value)
             => value switch
             {
@@ -166,6 +178,9 @@ namespace Bar
                 global::Foo.MyEnum.Third => nameof(global::Foo.MyEnum.Third),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::Foo.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Determines whether one or more bit fields are set in the current instance.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptEnumInGlobalNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptEnumInGlobalNamespace.verified.txt
@@ -150,12 +150,24 @@ using System;
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyEnum value)
             => value switch
             {
@@ -164,6 +176,9 @@ using System;
                 global::MyEnum.Third => nameof(global::MyEnum.Third),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Determines whether one or more bit fields are set in the current instance.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptExternalEnumToString.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptExternalEnumToString.verified.txt
@@ -152,12 +152,24 @@ namespace System
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::System.StringComparison"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::System.StringComparison value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::System.StringComparison"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::System.StringComparison value)
             => value switch
             {
@@ -169,6 +181,9 @@ namespace System
                 global::System.StringComparison.OrdinalIgnoreCase => nameof(global::System.StringComparison.OrdinalIgnoreCase),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::System.StringComparison value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptHasFlag.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptHasFlag.verified.txt
@@ -152,12 +152,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -166,6 +178,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Third => nameof(global::MyTestNameSpace.MyEnum.Third),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Determines whether one or more bit fields are set in the current instance.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptMultipleEnumsToString.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptMultipleEnumsToString.verified.txt
@@ -152,12 +152,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -166,6 +178,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Third => nameof(global::MyTestNameSpace.MyEnum.Third),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.
@@ -666,12 +681,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.AnotherEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.AnotherEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.AnotherEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.AnotherEnum value)
             => value switch
             {
@@ -680,6 +707,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.AnotherEnum.Third => nameof(global::MyTestNameSpace.AnotherEnum.Third),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.AnotherEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptToString.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptToString.verified.txt
@@ -152,12 +152,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -165,6 +177,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptToStringWhenCsharp11.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptToStringWhenCsharp11.verified.txt
@@ -152,12 +152,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -165,6 +177,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptUsingInterceptableAttributeToString.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptUsingInterceptableAttributeToString.verified.txt
@@ -152,12 +152,24 @@ namespace System
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::System.StringComparison"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::System.StringComparison value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::System.StringComparison"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::System.StringComparison value)
             => value switch
             {
@@ -169,6 +181,9 @@ namespace System
                 global::System.StringComparison.OrdinalIgnoreCase => nameof(global::System.StringComparison.OrdinalIgnoreCase),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::System.StringComparison value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptEnumToStringInOldSDK.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptEnumToStringInOldSDK.verified.txt
@@ -152,12 +152,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -165,6 +177,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptInterceptableAttributeEnumInOldSDK.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptInterceptableAttributeEnumInOldSDK.verified.txt
@@ -152,12 +152,24 @@ namespace System
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::System.StringComparison"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::System.StringComparison value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::System.StringComparison"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::System.StringComparison value)
             => value switch
             {
@@ -169,6 +181,9 @@ namespace System
                 global::System.StringComparison.OrdinalIgnoreCase => nameof(global::System.StringComparison.OrdinalIgnoreCase),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::System.StringComparison value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotGenerateWarningsForUseOfObsoleteEnums_CS0612_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotGenerateWarningsForUseOfObsoleteEnums_CS0612_Issue97.verified.txt
@@ -28,12 +28,24 @@ using System;
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::OtherEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::OtherEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::OtherEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::OtherEnum value)
             => value switch
             {
@@ -41,6 +53,9 @@ using System;
                 global::OtherEnum.Second => nameof(global::OtherEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::OtherEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotGenerateWarningsForUseOfObsoleteEnums_CS0618_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotGenerateWarningsForUseOfObsoleteEnums_CS0618_Issue97.verified.txt
@@ -28,12 +28,24 @@ using System;
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::OtherEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::OtherEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::OtherEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::OtherEnum value)
             => value switch
             {
@@ -41,6 +53,9 @@ using System;
                 global::OtherEnum.Second => nameof(global::OtherEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::OtherEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptEnumMarkedAsNotInterceptable.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptEnumMarkedAsNotInterceptable.verified.txt
@@ -152,12 +152,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -166,6 +178,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Third => nameof(global::MyTestNameSpace.MyEnum.Third),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.
@@ -666,12 +681,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.AnotherEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.AnotherEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.AnotherEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.AnotherEnum value)
             => value switch
             {
@@ -680,6 +707,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.AnotherEnum.Third => nameof(global::MyTestNameSpace.AnotherEnum.Third),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.AnotherEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Determines whether one or more bit fields are set in the current instance.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptExternalEnumMarkedAsNotInterceptable.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptExternalEnumMarkedAsNotInterceptable.verified.txt
@@ -152,12 +152,24 @@ namespace System
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::System.StringComparison"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::System.StringComparison value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::System.StringComparison"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::System.StringComparison value)
             => value switch
             {
@@ -169,6 +181,9 @@ namespace System
                 global::System.StringComparison.OrdinalIgnoreCase => nameof(global::System.StringComparison.OrdinalIgnoreCase),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::System.StringComparison value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.
@@ -720,12 +735,24 @@ namespace System
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::System.DateTimeKind"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::System.DateTimeKind value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::System.DateTimeKind"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::System.DateTimeKind value)
             => value switch
             {
@@ -734,6 +761,9 @@ namespace System
                 global::System.DateTimeKind.Local => nameof(global::System.DateTimeKind.Local),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::System.DateTimeKind value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptToStringWhenDisabled.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptToStringWhenDisabled.verified.txt
@@ -152,12 +152,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -165,6 +177,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptToStringWhenOldCsharp.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptToStringWhenOldCsharp.verified.txt
@@ -152,12 +152,24 @@ namespace MyTestNameSpace
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::MyTestNameSpace.MyEnum value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::MyTestNameSpace.MyEnum"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::MyTestNameSpace.MyEnum value)
             => value switch
             {
@@ -165,6 +177,9 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesEnumCorrectly.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesEnumCorrectly.verified.txt
@@ -30,12 +30,24 @@ namespace Something.Blah
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::Something.Blah.ShortName"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::Something.Blah.ShortName value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::Something.Blah.ShortName"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::Something.Blah.ShortName value)
             => value switch
             {
@@ -43,6 +55,9 @@ namespace Something.Blah
                 global::Something.Blah.ShortName.Second => nameof(global::Something.Blah.ShortName.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::Something.Blah.ShortName value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Returns a boolean telling whether the given enum value exists in the enumeration.

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesFlagsEnumCorrectly.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesFlagsEnumCorrectly.verified.txt
@@ -30,12 +30,24 @@ namespace Something.Blah
 
         /// <summary>
         /// Returns the string representation of the <see cref="global::Something.Blah.ShortName"/> value.
-        /// If the attribute is decorated with a <c>[Display]</c> attribute, then
+        /// If the attribute is decorated with a <c>[Display]</c> or <c>[Description]</c>attribute, then
         /// uses the provided value. Otherwise uses the name of the member, equivalent to
         /// calling <c>ToString()</c> on <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value to retrieve the string value for</param>
+        /// <param name="useMetadataAttributes">If <c>true</c> uses the value provided in the
+        /// <c>[Display]</c> or <c>[Description]</c>attribute as the string representation of the member.
+        /// If <c>false</c>, always uses the name of the member, the same as if <c>ToString()</c> was called.</param>
         /// <returns>The string representation of the value</returns>
+        public static string ToStringFast(this global::Something.Blah.ShortName value, bool useMetadataAttributes)
+            => useMetadataAttributes ? value.ToStringFastWithMetadata() : value.ToStringFast();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="global::Something.Blah.ShortName"/> value.
+        /// Directly equivalent to calling <c>ToString()</c> on <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value to retrieve the string value for</param>
+        /// <returns>The string representation of the value, the same as that returned by <c>ToString()</c></returns>
         public static string ToStringFast(this global::Something.Blah.ShortName value)
             => value switch
             {
@@ -43,6 +55,9 @@ namespace Something.Blah
                 global::Something.Blah.ShortName.Second => nameof(global::Something.Blah.ShortName.Second),
                 _ => value.ToString(),
             };
+
+        private static string ToStringFastWithMetadata(this global::Something.Blah.ShortName value)
+            => value.ToStringFast();
 
         /// <summary>
         /// Determines whether one or more bit fields are set in the current instance.


### PR DESCRIPTION
> [!WARNING]
> This PR contains a big breaking change, please read! 

Up to now, the default behaviour of `ToString()` and `ToStringFast()` have differed. `ToStringFast()` also takes into account metadata attributes like `[DisplayName]` and `[Description]`. This is a very useful feature, but it's unfortunate that it breaks the symmetry with `ToString()`.

For the other helpers, `Parse`, `TryParse` etc, we have an optional parameter `allowMatchingMetadataAttribute` to control whether or not to look at the `[DisplayName]` and `[Description]` attributes. This PR adds the same thing for `ToStringFast()`.

In summary, this PR:

- Changes the behaviour of `ToStringFast()` to _not_ look at the metadata attributes
- Adds a new method `ToStringFastWithMetadata()` that uses the old behaviour (i.e. uses the metadata attributes if available)
- Adds an overload with a boolean flag to specify whether to use the metadata attributes: `ToStringFast(bool useMetadataAttributes)`

It's unfortunate to make the breaking change this late, but I think it's important to add the consistency before going v1, especially considering the interceptor support