### PR TITLE
Enable interceptor by default

### DIFF
--- a/src/NetEscapades.EnumGenerators.Interceptors/EnumGenerator.cs
+++ b/src/NetEscapades.EnumGenerators.Interceptors/EnumGenerator.cs
@@ -37,15 +37,15 @@ public class EnumGenerator : IIncrementalGenerator
             .SelectMany(static (m, _) => m!.Value)
             .WithTrackingName(TrackingNames.InitialExternalExtraction);
 
-        var interceptionExplicitlyEnabled = context.AnalyzerConfigOptionsProvider
+        var interceptionEnabledSetting = context.AnalyzerConfigOptionsProvider
             .Select((x, _) =>
                 x.GlobalOptions.TryGetValue($"build_property.{Constants.EnabledPropertyName}", out var enableSwitch)
-                && enableSwitch.Equals("true", StringComparison.Ordinal));
+                && !enableSwitch.Equals("false", StringComparison.Ordinal));
 
         var csharpSufficient = context.CompilationProvider
             .Select((x,_) => x is CSharpCompilation { LanguageVersion: LanguageVersion.Default or >= LanguageVersion.CSharp11 });
 
-        var settings = interceptionExplicitlyEnabled
+        var settings = interceptionEnabledSetting
             .Combine(csharpSufficient)
             .WithTrackingName(TrackingNames.Settings);
 

--- a/src/NetEscapades.EnumGenerators.Interceptors/NetEscapades.EnumGenerators.Interceptors.csproj
+++ b/src/NetEscapades.EnumGenerators.Interceptors/NetEscapades.EnumGenerators.Interceptors.csproj
@@ -34,8 +34,8 @@
     <None Include="$(OutputPath)\NetEscapades.EnumGenerators.Interceptors.Attributes.xml" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
     <None Include="$(OutputPath)\NetEscapades.EnumGenerators.Interceptors.Attributes.dll" Pack="true" PackagePath="lib\net451" Visible="false" />
     <None Include="$(OutputPath)\NetEscapades.EnumGenerators.Interceptors.Attributes.xml" Pack="true" PackagePath="lib\net451" Visible="false" />
-    <None Include="NetEscapades.EnumGenerators.Interceptors.props" Pack="true" PackagePath="build" Visible="false" />
-    <None Include="NetEscapades.EnumGenerators.Interceptors.targets" Pack="true" PackagePath="build" Visible="false" />
+    <None Include="NetEscapades.EnumGenerators.Interceptors.props" Pack="true" PackagePath="build" Visible="true" />
+    <None Include="NetEscapades.EnumGenerators.Interceptors.targets" Pack="true" PackagePath="build" Visible="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetEscapades.EnumGenerators.Interceptors/NetEscapades.EnumGenerators.Interceptors.targets
+++ b/src/NetEscapades.EnumGenerators.Interceptors/NetEscapades.EnumGenerators.Interceptors.targets
@@ -1,6 +1,6 @@
 <Project InitialTargets="NetEscapades_EnumGenerators_Interceptors">
   <Target Name="NetEscapades_EnumGenerators_Interceptors">
-    <PropertyGroup Condition="'$(EnableEnumGeneratorInterceptor)' == 'true'">
+    <PropertyGroup Condition="'$(EnableEnumGeneratorInterceptor)' != 'false'">
       <InterceptorsNamespaces>$(InterceptorsNamespaces);NetEscapades.EnumGenerators</InterceptorsNamespaces>
       <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);NetEscapades.EnumGenerators</InterceptorsPreviewNamespaces>
     </PropertyGroup>

--- a/tests/NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests/NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests.csproj
+++ b/tests/NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests/NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests.csproj
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
     <DefineConstants>$(DefineConstants);NUGET_INTERCEPTOR_TESTS</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' != 'net48'">$(DefineConstants);READONLYSPAN</DefineConstants>
-    <EnableEnumGeneratorInterceptor>true</EnableEnumGeneratorInterceptor>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/NetEscapades.EnumGenerators.Nuget.NetStandard.Interceptors.IntegrationTests/NetEscapades.EnumGenerators.Nuget.NetStandard.Interceptors.IntegrationTests.csproj
+++ b/tests/NetEscapades.EnumGenerators.Nuget.NetStandard.Interceptors.IntegrationTests/NetEscapades.EnumGenerators.Nuget.NetStandard.Interceptors.IntegrationTests.csproj
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
     <DefineConstants>$(DefineConstants);NUGET_NETSTANDARD_INTERCEPTOR_TESTS</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' != 'net48'">$(DefineConstants);READONLYSPAN</DefineConstants>
-    <EnableEnumGeneratorInterceptor>true</EnableEnumGeneratorInterceptor>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There's no point in requiring users to add an extra flag now that they already need to add an extra package