### PR TITLE
Offer methods for underlying values

### DIFF
--- a/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
+++ b/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
@@ -855,7 +855,22 @@ namespace ").Append(enumToGenerate.Namespace).Append(@"
                     return false;
             }
         }
-#endif
+#endif");
+
+        sb.Append(@"
+
+        /// <summary>
+        /// Cast a value of <see cref=""").Append(fullyQualifiedName).Append(@""" /> to the underlying type (<c>")
+            .Append(enumToGenerate.UnderlyingType).Append(@"</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref=""").Append(fullyQualifiedName).Append(@""" /> cast to the underlying type.</returns>
+        public static ").Append(enumToGenerate.UnderlyingType).Append(@" AsUnderlyingType(this ").Append(fullyQualifiedName).Append(@" value)
+        {
+            return (").Append(enumToGenerate.UnderlyingType).Append(@") value;
+        }");
+
+        sb.Append(@"
 
         /// <summary>
         /// Retrieves an array of the values of the members defined in
@@ -873,6 +888,30 @@ namespace ").Append(enumToGenerate.Namespace).Append(@"
         {
             sb.Append(@"
                 ").Append(fullyQualifiedName).Append('.').Append(member.Key).Append(',');
+        }
+
+        sb.Append(@"
+            };
+        }");
+
+        sb.Append(@"
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref=""").Append(fullyQualifiedName).Append(@""" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref=""").Append(fullyQualifiedName).Append(
+            @""" /></returns>
+        public static ").Append(enumToGenerate.UnderlyingType).Append(@"[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {");
+        foreach (var member in enumToGenerate.Names)
+        {
+            sb.Append(@"
+                (").Append(enumToGenerate.UnderlyingType).Append(") ").Append(fullyQualifiedName).Append('.').Append(member.Key).Append(',');
         }
 
         sb.Append(@"

--- a/tests/NetEscapades.EnumGenerators.Benchmarks/Program.cs
+++ b/tests/NetEscapades.EnumGenerators.Benchmarks/Program.cs
@@ -177,6 +177,40 @@ public class GetValuesBenchmark
 }
 
 [MemoryDiagnoser]
+public class GetValuesAsUnderlyingTypeBenchmark
+{
+#if NETFRAMEWORK
+    [Benchmark(Baseline = true)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int[] EnumGetValuesAsUnderlyingType()
+    {
+        return Enum.GetValues(typeof(TestEnum)).Cast<int>().ToArray();
+    }
+#elif NET7_OR_GREATER
+    [Benchmark(Baseline = true)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int[] EnumGetValuesAsUnderlyingType()
+    {
+        return Enum.GetValuesAsUnderlyingType<TestEnum>();
+    }
+#else
+    [Benchmark(Baseline = true)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int[] EnumGetValuesAsUnderlyingType()
+    {
+        return Enum.GetValues<TestEnum>().Cast<int>().ToArray();
+    }
+#endif
+
+    [Benchmark]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int[] ExtensionsGetValuesAsUnderlyingType()
+    {
+        return TestEnumExtensions.GetValuesAsUnderlyingType();
+    }
+}
+
+[MemoryDiagnoser]
 public class GetNamesBenchmark
 {
 #if NETFRAMEWORK

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInFooExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInFooExtensionsTests.cs
@@ -101,8 +101,15 @@ public class EnumInFooExtensionsTests : ExtensionTests<EnumInFoo>
     [MemberData(nameof(ValuesToParse))]
     public void GeneratesTryParseIgnoreCase(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: false);
 
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesAsUnderlyingType(EnumInFoo value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
+
     [Fact]
     public void GeneratesGetValues() => GeneratesGetValuesTest(EnumInFooExtensions.GetValues());
+
+    [Fact]
+    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(EnumInFooExtensions.GetValuesAsUnderlyingType());
 
     [Fact]
     public void GeneratesGetNames() => base.GeneratesGetNamesTest(EnumInFooExtensions.GetNames());

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInNamespaceExtensionsTests.cs
@@ -100,8 +100,15 @@ public class EnumInNamespaceExtensionsTests : ExtensionTests<EnumInNamespace>
     [MemberData(nameof(ValuesToParse))]
     public void GeneratesTryParseIgnoreCase(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: false);
 
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesAsUnderlyingType(EnumInNamespace value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
+
     [Fact]
     public void GeneratesGetValues() => GeneratesGetValuesTest(EnumInNamespaceExtensions.GetValues());
+
+    [Fact]
+    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(EnumInNamespaceExtensions.GetValuesAsUnderlyingType());
 
     [Fact]
     public void GeneratesGetNames() => base.GeneratesGetNamesTest(EnumInNamespaceExtensions.GetNames());

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDescriptionInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDescriptionInNamespaceExtensionsTests.cs
@@ -135,8 +135,15 @@ public class EnumWithDescriptionInNamespaceExtensionsTests : ExtensionTests<Enum
     public void GeneratesTryParseIgnoreCaseallowMatchingMetadataAttributeAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: true);
 #endif
 
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesAsUnderlyingType(EnumWithDescriptionInNamespace value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
+
     [Fact]
     public void GeneratesGetValues() => GeneratesGetValuesTest(EnumWithDescriptionInNamespaceExtensions.GetValues());
+
+    [Fact]
+    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(EnumWithDescriptionInNamespaceExtensions.GetValuesAsUnderlyingType());
 
     [Fact]
     public void GeneratesGetNames() => base.GeneratesGetNamesTest(EnumWithDescriptionInNamespaceExtensions.GetNames());

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDisplayNameInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDisplayNameInNamespaceExtensionsTests.cs
@@ -134,8 +134,15 @@ public class EnumWithDisplayNameInNamespaceExtensionsTests : ExtensionTests<Enum
     public void GeneratesTryParseIgnoreCaseallowMatchingMetadataAttributeAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: true);
 #endif
 
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesAsUnderlyingType(EnumWithDisplayNameInNamespace value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
+
     [Fact]
     public void GeneratesGetValues() => GeneratesGetValuesTest(EnumWithDisplayNameInNamespaceExtensions.GetValues());
+
+    [Fact]
+    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(EnumWithDisplayNameInNamespaceExtensions.GetValuesAsUnderlyingType());
 
     [Fact]
     public void GeneratesGetNames() => base.GeneratesGetNamesTest(EnumWithDisplayNameInNamespaceExtensions.GetNames());

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithSameDisplayNameExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithSameDisplayNameExtensionsTests.cs
@@ -134,8 +134,15 @@ public class EnumWithSameDisplayNameExtensionsTests : ExtensionTests<EnumWithSam
     public void GeneratesTryParseIgnoreCaseallowMatchingMetadataAttributeAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: true);
 #endif
 
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesAsUnderlyingType(EnumWithSameDisplayName value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
+
     [Fact]
     public void GeneratesGetValues() => GeneratesGetValuesTest(EnumWithSameDisplayNameExtensions.GetValues());
+
+    [Fact]
+    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(EnumWithSameDisplayNameExtensions.GetValuesAsUnderlyingType());
 
     [Fact]
     public void GeneratesGetNames() => base.GeneratesGetNamesTest(EnumWithSameDisplayNameExtensions.GetNames());

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/ExtensionTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/ExtensionTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Reflection;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -223,9 +224,27 @@ public abstract class ExtensionTests<T> where T : struct
         }
     }
 
+    protected void GeneratesAsUnderlyingTypeTest<TUnderlying>(T value, TUnderlying underlyingValue)
+        where TUnderlying : struct
+    {
+        var expected = (TUnderlying) (object) value;
+        underlyingValue.Should().Be(expected);
+    }
+
     protected void GeneratesGetValuesTest(T[] values)
     {
-        var expected = (T[])Enum.GetValues(typeof(T));
+        var expected = (T[]) Enum.GetValues(typeof(T));
+        values.Should().Equal(expected);
+    }
+
+    protected void GeneratesGetValuesAsUnderlyingTypeTest<TUnderlying>(TUnderlying[] values)
+        where TUnderlying : struct
+    {
+#if NET7_OR_GREATER
+        var expected = (TUnderlying[]) Enum.GetValuesAsUnderlyingType(typeof(T));
+#else
+        var expected = Enum.GetValues(typeof(T)).Cast<TUnderlying>().ToArray();
+#endif
         values.Should().Equal(expected);
     }
 

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/FlagsEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/FlagsEnumExtensionsTests.cs
@@ -142,8 +142,15 @@ public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum>
     public void GeneratesTryParseIgnoreCaseAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: false);
 #endif
 
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesAsUnderlyingType(FlagsEnum value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
+
     [Fact]
     public void GeneratesGetValues() => GeneratesGetValuesTest(FlagsEnumExtensions.GetValues());
+
+    [Fact]
+    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(FlagsEnumExtensions.GetValuesAsUnderlyingType());
 
     [Fact]
     public void GeneratesGetNames() => base.GeneratesGetNamesTest(FlagsEnumExtensions.GetNames());

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/LongEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/LongEnumExtensionsTests.cs
@@ -105,8 +105,15 @@ public class LongEnumExtensionsTests : ExtensionTests<LongEnum>
     public void GeneratesTryParseIgnoreCaseAsAspan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: false);
 #endif
 
+    [Theory]
+    [MemberData(nameof(ValidEnumValues))]
+    public void GeneratesAsUnderlyingType(LongEnum value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
+
     [Fact]
     public void GeneratesGetValues() => GeneratesGetValuesTest(LongEnumExtensions.GetValues());
+
+    [Fact]
+    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(LongEnumExtensions.GetValuesAsUnderlyingType());
 
     [Fact]
     public void GeneratesGetNames() => base.GeneratesGetNamesTest(LongEnumExtensions.GetNames());

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsForFlagsEnum_Params.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsForFlagsEnum_Params.verified.txt
@@ -499,6 +499,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -512,6 +522,23 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
                 global::MyTestNameSpace.MyEnum.Third,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
+                (int) global::MyTestNameSpace.MyEnum.Third,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInChildNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInChildNamespace.verified.txt
@@ -471,6 +471,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -483,6 +493,22 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInGlobalNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInGlobalNamespace.verified.txt
@@ -469,6 +469,16 @@
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -481,6 +491,22 @@
             {
                 global::MyEnum.First,
                 global::MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyEnum.First,
+                (int) global::MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInNestedClass.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInNestedClass.verified.txt
@@ -471,6 +471,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.InnerClass.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.InnerClass.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.InnerClass.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.InnerClass.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -483,6 +493,22 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.InnerClass.MyEnum.First,
                 global::MyTestNameSpace.InnerClass.MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.InnerClass.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.InnerClass.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.InnerClass.MyEnum.First,
+                (int) global::MyTestNameSpace.InnerClass.MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomName.verified.txt
@@ -471,6 +471,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -483,6 +493,22 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNames.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNames.verified.txt
@@ -601,6 +601,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -615,6 +625,24 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second,
                 global::MyTestNameSpace.MyEnum.Third,
                 global::MyTestNameSpace.MyEnum.Fourth,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
+                (int) global::MyTestNameSpace.MyEnum.Third,
+                (int) global::MyTestNameSpace.MyEnum.Fourth,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespace.verified.txt
@@ -471,6 +471,16 @@ namespace A.B
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -483,6 +493,22 @@ namespace A.B
             {
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespaceAndName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespaceAndName.verified.txt
@@ -471,6 +471,16 @@ namespace A.B
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -483,6 +493,22 @@ namespace A.B
             {
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithSameDisplayName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithSameDisplayName.verified.txt
@@ -587,6 +587,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -601,6 +611,24 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second,
                 global::MyTestNameSpace.MyEnum.Third,
                 global::MyTestNameSpace.MyEnum.Fourth,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
+                (int) global::MyTestNameSpace.MyEnum.Third,
+                (int) global::MyTestNameSpace.MyEnum.Fourth,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomName.verified.txt
@@ -487,6 +487,16 @@ namespace System
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::System.DateTimeKind" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::System.DateTimeKind" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::System.DateTimeKind value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::System.DateTimeKind" />.
         /// Note that this returns a new array with every invocation, so
@@ -500,6 +510,23 @@ namespace System
                 global::System.DateTimeKind.Unspecified,
                 global::System.DateTimeKind.Utc,
                 global::System.DateTimeKind.Local,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::System.DateTimeKind" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::System.DateTimeKind" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::System.DateTimeKind.Unspecified,
+                (int) global::System.DateTimeKind.Utc,
+                (int) global::System.DateTimeKind.Local,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomNamespace.verified.txt
@@ -487,6 +487,16 @@ namespace A.B
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::System.DateTimeKind" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::System.DateTimeKind" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::System.DateTimeKind value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::System.DateTimeKind" />.
         /// Note that this returns a new array with every invocation, so
@@ -500,6 +510,23 @@ namespace A.B
                 global::System.DateTimeKind.Unspecified,
                 global::System.DateTimeKind.Utc,
                 global::System.DateTimeKind.Local,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::System.DateTimeKind" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::System.DateTimeKind" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::System.DateTimeKind.Unspecified,
+                (int) global::System.DateTimeKind.Utc,
+                (int) global::System.DateTimeKind.Local,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomNamespaceAndName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomNamespaceAndName.verified.txt
@@ -487,6 +487,16 @@ namespace A.B
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::System.DateTimeKind" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::System.DateTimeKind" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::System.DateTimeKind value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::System.DateTimeKind" />.
         /// Note that this returns a new array with every invocation, so
@@ -500,6 +510,23 @@ namespace A.B
                 global::System.DateTimeKind.Unspecified,
                 global::System.DateTimeKind.Utc,
                 global::System.DateTimeKind.Local,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::System.DateTimeKind" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::System.DateTimeKind" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::System.DateTimeKind.Unspecified,
+                (int) global::System.DateTimeKind.Utc,
+                (int) global::System.DateTimeKind.Local,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForExternalEnum.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForExternalEnum.verified.txt
@@ -535,6 +535,16 @@ namespace System
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::System.StringComparison" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::System.StringComparison" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::System.StringComparison value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::System.StringComparison" />.
         /// Note that this returns a new array with every invocation, so
@@ -551,6 +561,26 @@ namespace System
                 global::System.StringComparison.InvariantCultureIgnoreCase,
                 global::System.StringComparison.Ordinal,
                 global::System.StringComparison.OrdinalIgnoreCase,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::System.StringComparison" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::System.StringComparison" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::System.StringComparison.CurrentCulture,
+                (int) global::System.StringComparison.CurrentCultureIgnoreCase,
+                (int) global::System.StringComparison.InvariantCulture,
+                (int) global::System.StringComparison.InvariantCultureIgnoreCase,
+                (int) global::System.StringComparison.Ordinal,
+                (int) global::System.StringComparison.OrdinalIgnoreCase,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForExternalFlagsEnum.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForExternalFlagsEnum.verified.txt
@@ -547,6 +547,16 @@ namespace System.IO
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::System.IO.FileShare" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::System.IO.FileShare" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::System.IO.FileShare value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::System.IO.FileShare" />.
         /// Note that this returns a new array with every invocation, so
@@ -563,6 +573,26 @@ namespace System.IO
                 global::System.IO.FileShare.ReadWrite,
                 global::System.IO.FileShare.Delete,
                 global::System.IO.FileShare.Inheritable,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::System.IO.FileShare" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::System.IO.FileShare" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::System.IO.FileShare.None,
+                (int) global::System.IO.FileShare.Read,
+                (int) global::System.IO.FileShare.Write,
+                (int) global::System.IO.FileShare.ReadWrite,
+                (int) global::System.IO.FileShare.Delete,
+                (int) global::System.IO.FileShare.Inheritable,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForMultipleExternalEnums.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForMultipleExternalEnums.verified.txt
@@ -696,6 +696,16 @@ namespace System
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::System.ConsoleColor" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::System.ConsoleColor" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::System.ConsoleColor value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::System.ConsoleColor" />.
         /// Note that this returns a new array with every invocation, so
@@ -722,6 +732,36 @@ namespace System
                 global::System.ConsoleColor.Magenta,
                 global::System.ConsoleColor.Yellow,
                 global::System.ConsoleColor.White,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::System.ConsoleColor" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::System.ConsoleColor" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::System.ConsoleColor.Black,
+                (int) global::System.ConsoleColor.DarkBlue,
+                (int) global::System.ConsoleColor.DarkGreen,
+                (int) global::System.ConsoleColor.DarkCyan,
+                (int) global::System.ConsoleColor.DarkRed,
+                (int) global::System.ConsoleColor.DarkMagenta,
+                (int) global::System.ConsoleColor.DarkYellow,
+                (int) global::System.ConsoleColor.Gray,
+                (int) global::System.ConsoleColor.DarkGray,
+                (int) global::System.ConsoleColor.Blue,
+                (int) global::System.ConsoleColor.Green,
+                (int) global::System.ConsoleColor.Cyan,
+                (int) global::System.ConsoleColor.Red,
+                (int) global::System.ConsoleColor.Magenta,
+                (int) global::System.ConsoleColor.Yellow,
+                (int) global::System.ConsoleColor.White,
             };
         }
 
@@ -1248,6 +1288,16 @@ namespace System
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::System.DateTimeKind" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::System.DateTimeKind" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::System.DateTimeKind value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::System.DateTimeKind" />.
         /// Note that this returns a new array with every invocation, so
@@ -1261,6 +1311,23 @@ namespace System
                 global::System.DateTimeKind.Unspecified,
                 global::System.DateTimeKind.Utc,
                 global::System.DateTimeKind.Local,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::System.DateTimeKind" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::System.DateTimeKind" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::System.DateTimeKind.Unspecified,
+                (int) global::System.DateTimeKind.Utc,
+                (int) global::System.DateTimeKind.Local,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanHandleNamespaceAndClassNameAreTheSame.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanHandleNamespaceAndClassNameAreTheSame.verified.txt
@@ -455,6 +455,16 @@ namespace Foo
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::Foo.TestEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::Foo.TestEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::Foo.TestEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::Foo.TestEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -466,6 +476,21 @@ namespace Foo
             return new[]
             {
                 global::Foo.TestEnum.Value1,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::Foo.TestEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::Foo.TestEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::Foo.TestEnum.Value1,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteEnums_CS0612_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteEnums_CS0612_Issue97.verified.txt
@@ -469,6 +469,16 @@
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -481,6 +491,22 @@
             {
                 global::MyEnum.First,
                 global::MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyEnum.First,
+                (int) global::MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteEnums_CS0618_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteEnums_CS0618_Issue97.verified.txt
@@ -469,6 +469,16 @@
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -481,6 +491,22 @@
             {
                 global::MyEnum.First,
                 global::MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyEnum.First,
+                (int) global::MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteMembers_CS0612_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteMembers_CS0612_Issue97.verified.txt
@@ -469,6 +469,16 @@
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -481,6 +491,22 @@
             {
                 global::MyEnum.First,
                 global::MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyEnum.First,
+                (int) global::MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteMembers_CS0618_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteMembers_CS0618_Issue97.verified.txt
@@ -469,6 +469,16 @@
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -481,6 +491,22 @@
             {
                 global::MyEnum.First,
                 global::MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyEnum.First,
+                (int) global::MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.HandlesStringsWithQuotesAndSlashesInDescription.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.HandlesStringsWithQuotesAndSlashesInDescription.verified.txt
@@ -660,6 +660,16 @@ namespace Test
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::Test.StringTesting" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::Test.StringTesting" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::Test.StringTesting value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::Test.StringTesting" />.
         /// Note that this returns a new array with every invocation, so
@@ -675,6 +685,25 @@ namespace Test
                 global::Test.StringTesting.Backslash,
                 global::Test.StringTesting.BackslashLiteral,
                 global::Test.StringTesting.NewLine,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::Test.StringTesting" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::Test.StringTesting" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::Test.StringTesting.Quotes,
+                (int) global::Test.StringTesting.LiteralQuotes,
+                (int) global::Test.StringTesting.Backslash,
+                (int) global::Test.StringTesting.BackslashLiteral,
+                (int) global::Test.StringTesting.NewLine,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanHandleEnumsWithSameNameInDifferentNamespaces.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanHandleEnumsWithSameNameInDifferentNamespaces.verified.txt
@@ -589,6 +589,16 @@ namespace Foo
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::Foo.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::Foo.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::Foo.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::Foo.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -602,6 +612,23 @@ namespace Foo
                 global::Foo.MyEnum.First,
                 global::Foo.MyEnum.Second,
                 global::Foo.MyEnum.Third,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::Foo.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::Foo.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::Foo.MyEnum.First,
+                (int) global::Foo.MyEnum.Second,
+                (int) global::Foo.MyEnum.Third,
             };
         }
 
@@ -1127,6 +1154,16 @@ namespace Bar
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::Bar.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::Bar.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::Bar.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::Bar.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -1140,6 +1177,23 @@ namespace Bar
                 global::Bar.MyEnum.First,
                 global::Bar.MyEnum.Second,
                 global::Bar.MyEnum.Third,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::Bar.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::Bar.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::Bar.MyEnum.First,
+                (int) global::Bar.MyEnum.Second,
+                (int) global::Bar.MyEnum.Third,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptEnumInDifferentNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptEnumInDifferentNamespace.verified.txt
@@ -589,6 +589,16 @@ namespace Bar
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::Foo.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::Foo.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::Foo.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::Foo.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -602,6 +612,23 @@ namespace Bar
                 global::Foo.MyEnum.First,
                 global::Foo.MyEnum.Second,
                 global::Foo.MyEnum.Third,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::Foo.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::Foo.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::Foo.MyEnum.First,
+                (int) global::Foo.MyEnum.Second,
+                (int) global::Foo.MyEnum.Third,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptEnumInGlobalNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptEnumInGlobalNamespace.verified.txt
@@ -587,6 +587,16 @@ namespace NetEscapades.EnumGenerators
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -600,6 +610,23 @@ namespace NetEscapades.EnumGenerators
                 global::MyEnum.First,
                 global::MyEnum.Second,
                 global::MyEnum.Third,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyEnum.First,
+                (int) global::MyEnum.Second,
+                (int) global::MyEnum.Third,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptExternalEnumToString.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptExternalEnumToString.verified.txt
@@ -625,6 +625,16 @@ namespace System
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::System.StringComparison" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::System.StringComparison" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::System.StringComparison value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::System.StringComparison" />.
         /// Note that this returns a new array with every invocation, so
@@ -641,6 +651,26 @@ namespace System
                 global::System.StringComparison.InvariantCultureIgnoreCase,
                 global::System.StringComparison.Ordinal,
                 global::System.StringComparison.OrdinalIgnoreCase,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::System.StringComparison" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::System.StringComparison" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::System.StringComparison.CurrentCulture,
+                (int) global::System.StringComparison.CurrentCultureIgnoreCase,
+                (int) global::System.StringComparison.InvariantCulture,
+                (int) global::System.StringComparison.InvariantCultureIgnoreCase,
+                (int) global::System.StringComparison.Ordinal,
+                (int) global::System.StringComparison.OrdinalIgnoreCase,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptHasFlag.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptHasFlag.verified.txt
@@ -589,6 +589,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -602,6 +612,23 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
                 global::MyTestNameSpace.MyEnum.Third,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
+                (int) global::MyTestNameSpace.MyEnum.Third,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptMultipleEnumsToString.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptMultipleEnumsToString.verified.txt
@@ -577,6 +577,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -590,6 +600,23 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
                 global::MyTestNameSpace.MyEnum.Third,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
+                (int) global::MyTestNameSpace.MyEnum.Third,
             };
         }
 
@@ -1103,6 +1130,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.AnotherEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.AnotherEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.AnotherEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.AnotherEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -1116,6 +1153,23 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.AnotherEnum.First,
                 global::MyTestNameSpace.AnotherEnum.Second,
                 global::MyTestNameSpace.AnotherEnum.Third,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.AnotherEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.AnotherEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.AnotherEnum.First,
+                (int) global::MyTestNameSpace.AnotherEnum.Second,
+                (int) global::MyTestNameSpace.AnotherEnum.Third,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptToString.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptToString.verified.txt
@@ -561,6 +561,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -573,6 +583,22 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptToStringWhenCsharp11.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptToStringWhenCsharp11.verified.txt
@@ -561,6 +561,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -573,6 +583,22 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptUsingInterceptableAttributeToString.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptUsingInterceptableAttributeToString.verified.txt
@@ -625,6 +625,16 @@ namespace System
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::System.StringComparison" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::System.StringComparison" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::System.StringComparison value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::System.StringComparison" />.
         /// Note that this returns a new array with every invocation, so
@@ -641,6 +651,26 @@ namespace System
                 global::System.StringComparison.InvariantCultureIgnoreCase,
                 global::System.StringComparison.Ordinal,
                 global::System.StringComparison.OrdinalIgnoreCase,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::System.StringComparison" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::System.StringComparison" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::System.StringComparison.CurrentCulture,
+                (int) global::System.StringComparison.CurrentCultureIgnoreCase,
+                (int) global::System.StringComparison.InvariantCulture,
+                (int) global::System.StringComparison.InvariantCultureIgnoreCase,
+                (int) global::System.StringComparison.Ordinal,
+                (int) global::System.StringComparison.OrdinalIgnoreCase,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptEnumWithoutInterceptorPackage.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptEnumWithoutInterceptorPackage.verified.txt
@@ -561,6 +561,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -573,6 +583,22 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptUsageInStringInterpolation.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptUsageInStringInterpolation.verified.txt
@@ -561,6 +561,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -573,6 +583,22 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptUsageWithEnumDirectly.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptUsageWithEnumDirectly.verified.txt
@@ -561,6 +561,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -573,6 +583,22 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotGenerateWarningsForUseOfObsoleteEnums_CS0612_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotGenerateWarningsForUseOfObsoleteEnums_CS0612_Issue97.verified.txt
@@ -469,6 +469,16 @@
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::OtherEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::OtherEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::OtherEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::OtherEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -481,6 +491,22 @@
             {
                 global::OtherEnum.First,
                 global::OtherEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::OtherEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::OtherEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::OtherEnum.First,
+                (int) global::OtherEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotGenerateWarningsForUseOfObsoleteEnums_CS0618_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotGenerateWarningsForUseOfObsoleteEnums_CS0618_Issue97.verified.txt
@@ -469,6 +469,16 @@
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::OtherEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::OtherEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::OtherEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::OtherEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -481,6 +491,22 @@
             {
                 global::OtherEnum.First,
                 global::OtherEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::OtherEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::OtherEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::OtherEnum.First,
+                (int) global::OtherEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptEnumMarkedAsNotInterceptable.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptEnumMarkedAsNotInterceptable.verified.txt
@@ -577,6 +577,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -590,6 +600,23 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
                 global::MyTestNameSpace.MyEnum.Third,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
+                (int) global::MyTestNameSpace.MyEnum.Third,
             };
         }
 
@@ -1115,6 +1142,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.AnotherEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.AnotherEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.AnotherEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.AnotherEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -1128,6 +1165,23 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.AnotherEnum.First,
                 global::MyTestNameSpace.AnotherEnum.Second,
                 global::MyTestNameSpace.AnotherEnum.Third,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.AnotherEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.AnotherEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.AnotherEnum.First,
+                (int) global::MyTestNameSpace.AnotherEnum.Second,
+                (int) global::MyTestNameSpace.AnotherEnum.Third,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptExternalEnumMarkedAsNotInterceptable.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptExternalEnumMarkedAsNotInterceptable.verified.txt
@@ -625,6 +625,16 @@ namespace System
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::System.StringComparison" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::System.StringComparison" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::System.StringComparison value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::System.StringComparison" />.
         /// Note that this returns a new array with every invocation, so
@@ -641,6 +651,26 @@ namespace System
                 global::System.StringComparison.InvariantCultureIgnoreCase,
                 global::System.StringComparison.Ordinal,
                 global::System.StringComparison.OrdinalIgnoreCase,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::System.StringComparison" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::System.StringComparison" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::System.StringComparison.CurrentCulture,
+                (int) global::System.StringComparison.CurrentCultureIgnoreCase,
+                (int) global::System.StringComparison.InvariantCulture,
+                (int) global::System.StringComparison.InvariantCultureIgnoreCase,
+                (int) global::System.StringComparison.Ordinal,
+                (int) global::System.StringComparison.OrdinalIgnoreCase,
             };
         }
 
@@ -1157,6 +1187,16 @@ namespace System
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::System.DateTimeKind" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::System.DateTimeKind" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::System.DateTimeKind value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::System.DateTimeKind" />.
         /// Note that this returns a new array with every invocation, so
@@ -1170,6 +1210,23 @@ namespace System
                 global::System.DateTimeKind.Unspecified,
                 global::System.DateTimeKind.Utc,
                 global::System.DateTimeKind.Local,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::System.DateTimeKind" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::System.DateTimeKind" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::System.DateTimeKind.Unspecified,
+                (int) global::System.DateTimeKind.Utc,
+                (int) global::System.DateTimeKind.Local,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptToStringWhenDisabled.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptToStringWhenDisabled.verified.txt
@@ -561,6 +561,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -573,6 +583,22 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptToStringWhenOldCsharp.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptToStringWhenOldCsharp.verified.txt
@@ -561,6 +561,16 @@ namespace MyTestNameSpace
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::MyTestNameSpace.MyEnum" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::MyTestNameSpace.MyEnum" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::MyTestNameSpace.MyEnum value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::MyTestNameSpace.MyEnum" />.
         /// Note that this returns a new array with every invocation, so
@@ -573,6 +583,22 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First,
                 global::MyTestNameSpace.MyEnum.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::MyTestNameSpace.MyEnum" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::MyTestNameSpace.MyEnum" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::MyTestNameSpace.MyEnum.First,
+                (int) global::MyTestNameSpace.MyEnum.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesEnumCorrectly.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesEnumCorrectly.verified.txt
@@ -471,6 +471,16 @@ namespace Something.Blah
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::Something.Blah.ShortName" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::Something.Blah.ShortName" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::Something.Blah.ShortName value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::Something.Blah.ShortName" />.
         /// Note that this returns a new array with every invocation, so
@@ -483,6 +493,22 @@ namespace Something.Blah
             {
                 global::Something.Blah.ShortName.First,
                 global::Something.Blah.ShortName.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::Something.Blah.ShortName" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::Something.Blah.ShortName" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::Something.Blah.ShortName.First,
+                (int) global::Something.Blah.ShortName.Second,
             };
         }
 

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesFlagsEnumCorrectly.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesFlagsEnumCorrectly.verified.txt
@@ -483,6 +483,16 @@ namespace Something.Blah
 #endif
 
         /// <summary>
+        /// Cast a value of <see cref="global::Something.Blah.ShortName" /> to the underlying type (<c>int</c>).
+        /// This is mainly a convenience method.
+        /// </summary>
+        /// <returns>The value of <see cref="global::Something.Blah.ShortName" /> cast to the underlying type.</returns>
+        public static int AsUnderlyingType(this global::Something.Blah.ShortName value)
+        {
+            return (int) value;
+        }
+
+        /// <summary>
         /// Retrieves an array of the values of the members defined in
         /// <see cref="global::Something.Blah.ShortName" />.
         /// Note that this returns a new array with every invocation, so
@@ -495,6 +505,22 @@ namespace Something.Blah
             {
                 global::Something.Blah.ShortName.First,
                 global::Something.Blah.ShortName.Second,
+            };
+        }
+
+        /// <summary>
+        /// Retrieves an array of the underlying-values of the members defined in
+        /// <see cref="global::Something.Blah.ShortName" />.
+        /// Note that this returns a new array with every invocation, so
+        /// should be cached if appropriate.
+        /// </summary>
+        /// <returns>An array of the underlying-values defined in <see cref="global::Something.Blah.ShortName" /></returns>
+        public static int[] GetValuesAsUnderlyingType()
+        {
+            return new[]
+            {
+                (int) global::Something.Blah.ShortName.First,
+                (int) global::Something.Blah.ShortName.Second,
             };
         }
 


### PR DESCRIPTION
While often `int` may be a good enough choice, especially for projects with enums based on different types it can become hard to track, which underlying type belongs to which enum. An added benefit is, that (as you don't support `"D"`-format-string) you can use `AsUnderlyingType` to have a numeric output, if needed. Also the build in `GetValuesAsUnderlyingType` is of course a lot slower than the quite trivial generated alternative.