### PR TITLE
Add support for enums, that are not ordered by value

### DIFF
--- a/src/NetEscapades.EnumGenerators/EnumGenerator.cs
+++ b/src/NetEscapades.EnumGenerators/EnumGenerator.cs
@@ -178,8 +178,7 @@ public class EnumGenerator : IIncrementalGenerator
 
         foreach (var member in enumMembers)
         {
-            if (member is not IFieldSymbol field
-                || field.ConstantValue is null)
+            if (member is not IFieldSymbol {ConstantValue: { } constantValue})
             {
                 continue;
             }
@@ -222,7 +221,7 @@ public class EnumGenerator : IIncrementalGenerator
                 isDisplayNameTheFirstPresence = displayNames.Add(displayName);    
             }
             
-            members.Add((member.Name, new EnumValueOption(displayName, isDisplayNameTheFirstPresence)));
+            members.Add((member.Name, new EnumValueOption(displayName, isDisplayNameTheFirstPresence, constantValue)));
         }
 
         return new EnumToGenerate(

--- a/src/NetEscapades.EnumGenerators/EnumToGenerate.cs
+++ b/src/NetEscapades.EnumGenerators/EnumToGenerate.cs
@@ -25,7 +25,7 @@ public readonly record struct EnumToGenerate
         string fullyQualifiedName,
         string underlyingType,
         bool isPublic,
-        List<(string, EnumValueOption)> names,
+        List<(string Key, EnumValueOption Value)> names,
         bool hasFlags,
         bool isDisplayAttributeUsed)
     {

--- a/src/NetEscapades.EnumGenerators/EnumValueOption.cs
+++ b/src/NetEscapades.EnumGenerators/EnumValueOption.cs
@@ -7,16 +7,19 @@ public readonly struct EnumValueOption : IEquatable<EnumValueOption>
     /// </summary>
     public string? DisplayName { get; }
     public bool IsDisplayNameTheFirstPresence { get; }
+    public object ConstantValue { get; }
 
-    public EnumValueOption(string? displayName, bool isDisplayNameTheFirstPresence)
+    public EnumValueOption(string? displayName, bool isDisplayNameTheFirstPresence, object constantValue)
     {
         DisplayName = displayName;
         IsDisplayNameTheFirstPresence = isDisplayNameTheFirstPresence;
+        ConstantValue = constantValue;
     }
     
     public bool Equals(EnumValueOption other)
     {
         return DisplayName == other.DisplayName &&
-               IsDisplayNameTheFirstPresence == other.IsDisplayNameTheFirstPresence;
+               IsDisplayNameTheFirstPresence == other.IsDisplayNameTheFirstPresence &&
+               Equals(ConstantValue, other.ConstantValue);
     }
 }

--- a/src/NetEscapades.EnumGenerators/EquatableArray.cs
+++ b/src/NetEscapades.EnumGenerators/EquatableArray.cs
@@ -8,13 +8,19 @@ namespace NetEscapades.EnumGenerators;
 /// An immutable, equatable array. This is equivalent to <see cref="Array{T}"/> but with value equality support.
 /// </summary>
 /// <typeparam name="T">The type of values in the array.</typeparam>
-public readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnumerable<T>
+public readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IReadOnlyList<T>
     where T : IEquatable<T>
 {
     /// <summary>
     /// The underlying <typeparamref name="T"/> array.
     /// </summary>
     private readonly T[]? _array;
+
+    /// <summary>
+    /// Get value at <paramref name="index"/>
+    /// </summary>
+    /// <param name="index">The index of the value to get</param>
+    public T this[int index] => _array[index];
 
     /// <summary>
     /// Creates a new <see cref="EquatableArray{T}"/> instance.

--- a/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
+++ b/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
@@ -1289,6 +1289,7 @@ public static class SourceGenerationHelper
                     }
             """);
 
+        var orderedNames = GetNamesOrderedByValue(enumToGenerate);
         sb.Append(
             """
 
@@ -1314,7 +1315,7 @@ public static class SourceGenerationHelper
                         return new[]
                         {
             """);
-        foreach (var member in enumToGenerate.Names)
+        foreach (var member in orderedNames)
         {
             sb.Append(
                 """
@@ -1355,7 +1356,7 @@ public static class SourceGenerationHelper
                         return new[]
                         {
             """);
-        foreach (var member in enumToGenerate.Names)
+        foreach (var member in orderedNames)
         {
             sb.Append(
                 """
@@ -1394,7 +1395,7 @@ public static class SourceGenerationHelper
                         {
             """);
 
-        foreach (var member in enumToGenerate.Names)
+        foreach (var member in orderedNames)
         {
             sb.Append(
                 """
@@ -1432,5 +1433,16 @@ public static class SourceGenerationHelper
             .Replace(' ', '_')
             .ToString();
         return (content, filename);
+    }
+
+    private static List<(string Key, EnumValueOption Value)> GetNamesOrderedByValue(EnumToGenerate enumToGenerate)
+    {
+        // We order by underlying value, keeping the order of names with the same value, as they were defined
+        return enumToGenerate.Names
+            .Select((name, pos) => (name, pos))
+            .OrderBy(tuple => tuple.name.Value.ConstantValue)
+            .ThenBy(tuple => tuple.pos)
+            .Select(tuple => tuple.name)
+            .ToList();
     }
 }

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/Enums.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/Enums.cs
@@ -111,8 +111,8 @@ namespace NetEscapades.EnumGenerators.Nuget.NetStandard.Interceptors.Integration
     [EnumExtensions]
     public enum LongEnum: long
     {
-        First = 0,
         Second = 1,
+        First = 0,
         Third = 2,
     }
 
@@ -121,8 +121,8 @@ namespace NetEscapades.EnumGenerators.Nuget.NetStandard.Interceptors.Integration
     public enum FlagsEnum
     {
         None = 0,
-        First = 1 << 0,
         Second = 1 << 1,
+        First = 1 << 0,
         Third = 1 << 2,
         Fourth = 1 << 3,
         ThirdAndFourth = Third | Fourth,

--- a/tests/NetEscapades.EnumGenerators.Tests/SourceGenerationHelperSnapshotTests.cs
+++ b/tests/NetEscapades.EnumGenerators.Tests/SourceGenerationHelperSnapshotTests.cs
@@ -20,8 +20,8 @@ public class SourceGenerationHelperSnapshotTests
             isPublic: true,
             new List<(string Key, EnumValueOption Value)>
             {
-                ("First", new EnumValueOption(null, false)),
-                ("Second", new EnumValueOption(null, false)),
+                ("First", new EnumValueOption(null, false, 0)),
+                ("Second", new EnumValueOption(null, false, 1)),
             },
             hasFlags: false,
             isDisplayAttributeUsed: false);
@@ -44,8 +44,8 @@ public class SourceGenerationHelperSnapshotTests
             isPublic: true,
             new List<(string, EnumValueOption)>
             {
-                ("First", new EnumValueOption(null, false)),
-                ("Second", new EnumValueOption(null, false)),
+                ("First", new EnumValueOption(null, false, 0)),
+                ("Second", new EnumValueOption(null, false, 1)),
             },
             hasFlags: true,
             isDisplayAttributeUsed: false);


### PR DESCRIPTION
I learned so many new aspects of enums working on #132. To not too much surprise `Enum.GetValues`/`Enum.GetNames`/`Enum.GetValuesAsUnderlyingType` are ordered. Right now the generator always orders according to the source, but the `Enum`-metadata is ordered by underlying value.

This PR hence
- adds ordering by underlying value and then position in the source code
- reorders `LongEnum` and `FlagsEnum` in the tests to demonstrate behaviour identical to .NET