### PR TITLE
Directly ToString unnamed numeric values

### DIFF
--- a/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
+++ b/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
@@ -198,11 +198,30 @@ public static class SourceGenerationHelper
                 .Append(" => nameof(").Append(fullyQualifiedName).Append('.').Append(member.Key).Append("),");
         }
 
+        if (enumToGenerate.HasFlags)
+        {
+            // We currently don't handle ToString of custom flag-combinations, so lets fall back to the default
+            sb.Append(
+                """
+
+                                _ => value.ToString(),
+                            };
+                """);
+        }
+        else
+        {
+            // This should mean, that the value is not named -> generate a numeric string
+            sb.Append(
+                """
+
+                                _ => value.AsUnderlyingType().ToString(),
+                            };
+                """);
+        }
+
         sb.Append(
             """
 
-                            _ => value.ToString(),
-                        };
 
                     private static string ToStringFastWithMetadata(this 
             """).Append(fullyQualifiedName).Append(
@@ -236,12 +255,26 @@ public static class SourceGenerationHelper
                 }
             }
 
-            sb.Append(
-                """
+            if (enumToGenerate.HasFlags)
+            {
+                // We currently don't handle ToString of custom flag-combinations, so lets fall back to the default
+                sb.Append(
+                    """
 
-                                _ => value.ToString(),
-                            };
-                """);
+                                    _ => value.ToString(),
+                                };
+                    """);
+            }
+            else
+            {
+                // This should mean, that the value is not named -> generate a numeric string
+                sb.Append(
+                    """
+
+                                    _ => value.AsUnderlyingType().ToString(),
+                                };
+                    """);
+            }
         }
         else
         {

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInChildNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInChildNamespace.verified.txt
@@ -50,7 +50,7 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInGlobalNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInGlobalNamespace.verified.txt
@@ -48,7 +48,7 @@
             {
                 global::MyEnum.First => nameof(global::MyEnum.First),
                 global::MyEnum.Second => nameof(global::MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInNestedClass.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsInNestedClass.verified.txt
@@ -50,7 +50,7 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.InnerClass.MyEnum.First => nameof(global::MyTestNameSpace.InnerClass.MyEnum.First),
                 global::MyTestNameSpace.InnerClass.MyEnum.Second => nameof(global::MyTestNameSpace.InnerClass.MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.InnerClass.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomName.verified.txt
@@ -50,7 +50,7 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNames.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNames.verified.txt
@@ -52,7 +52,7 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 global::MyTestNameSpace.MyEnum.Third => nameof(global::MyTestNameSpace.MyEnum.Third),
                 global::MyTestNameSpace.MyEnum.Fourth => nameof(global::MyTestNameSpace.MyEnum.Fourth),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
@@ -62,7 +62,7 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second => "2nd",
                 global::MyTestNameSpace.MyEnum.Third => nameof(global::MyTestNameSpace.MyEnum.Third),
                 global::MyTestNameSpace.MyEnum.Fourth => "4th",
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         /// <summary>

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespace.verified.txt
@@ -50,7 +50,7 @@ namespace A.B
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespaceAndName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithCustomNamespaceAndName.verified.txt
@@ -50,7 +50,7 @@ namespace A.B
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithSameDisplayName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateEnumExtensionsWithSameDisplayName.verified.txt
@@ -52,7 +52,7 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 global::MyTestNameSpace.MyEnum.Third => nameof(global::MyTestNameSpace.MyEnum.Third),
                 global::MyTestNameSpace.MyEnum.Fourth => nameof(global::MyTestNameSpace.MyEnum.Fourth),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
@@ -62,7 +62,7 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.Second => "2nd",
                 global::MyTestNameSpace.MyEnum.Third => nameof(global::MyTestNameSpace.MyEnum.Third),
                 global::MyTestNameSpace.MyEnum.Fourth => "2nd",
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         /// <summary>

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomName.verified.txt
@@ -51,7 +51,7 @@ namespace System
                 global::System.DateTimeKind.Unspecified => nameof(global::System.DateTimeKind.Unspecified),
                 global::System.DateTimeKind.Utc => nameof(global::System.DateTimeKind.Utc),
                 global::System.DateTimeKind.Local => nameof(global::System.DateTimeKind.Local),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::System.DateTimeKind value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomNamespace.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomNamespace.verified.txt
@@ -51,7 +51,7 @@ namespace A.B
                 global::System.DateTimeKind.Unspecified => nameof(global::System.DateTimeKind.Unspecified),
                 global::System.DateTimeKind.Utc => nameof(global::System.DateTimeKind.Utc),
                 global::System.DateTimeKind.Local => nameof(global::System.DateTimeKind.Local),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::System.DateTimeKind value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomNamespaceAndName.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateExternalEnumExtensionsWithCustomNamespaceAndName.verified.txt
@@ -51,7 +51,7 @@ namespace A.B
                 global::System.DateTimeKind.Unspecified => nameof(global::System.DateTimeKind.Unspecified),
                 global::System.DateTimeKind.Utc => nameof(global::System.DateTimeKind.Utc),
                 global::System.DateTimeKind.Local => nameof(global::System.DateTimeKind.Local),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::System.DateTimeKind value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForExternalEnum.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForExternalEnum.verified.txt
@@ -54,7 +54,7 @@ namespace System
                 global::System.StringComparison.InvariantCultureIgnoreCase => nameof(global::System.StringComparison.InvariantCultureIgnoreCase),
                 global::System.StringComparison.Ordinal => nameof(global::System.StringComparison.Ordinal),
                 global::System.StringComparison.OrdinalIgnoreCase => nameof(global::System.StringComparison.OrdinalIgnoreCase),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::System.StringComparison value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForMultipleExternalEnums.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanGenerateForMultipleExternalEnums.verified.txt
@@ -65,7 +65,7 @@ namespace System
                 global::System.ConsoleColor.Magenta => nameof(global::System.ConsoleColor.Magenta),
                 global::System.ConsoleColor.Yellow => nameof(global::System.ConsoleColor.Yellow),
                 global::System.ConsoleColor.White => nameof(global::System.ConsoleColor.White),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::System.ConsoleColor value)
@@ -852,7 +852,7 @@ namespace System
                 global::System.DateTimeKind.Unspecified => nameof(global::System.DateTimeKind.Unspecified),
                 global::System.DateTimeKind.Utc => nameof(global::System.DateTimeKind.Utc),
                 global::System.DateTimeKind.Local => nameof(global::System.DateTimeKind.Local),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::System.DateTimeKind value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanHandleNamespaceAndClassNameAreTheSame.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.CanHandleNamespaceAndClassNameAreTheSame.verified.txt
@@ -49,7 +49,7 @@ namespace Foo
             => value switch
             {
                 global::Foo.TestEnum.Value1 => nameof(global::Foo.TestEnum.Value1),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::Foo.TestEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteEnums_CS0612_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteEnums_CS0612_Issue97.verified.txt
@@ -48,7 +48,7 @@
             {
                 global::MyEnum.First => nameof(global::MyEnum.First),
                 global::MyEnum.Second => nameof(global::MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteEnums_CS0618_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteEnums_CS0618_Issue97.verified.txt
@@ -48,7 +48,7 @@
             {
                 global::MyEnum.First => nameof(global::MyEnum.First),
                 global::MyEnum.Second => nameof(global::MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteMembers_CS0612_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteMembers_CS0612_Issue97.verified.txt
@@ -48,7 +48,7 @@
             {
                 global::MyEnum.First => nameof(global::MyEnum.First),
                 global::MyEnum.Second => nameof(global::MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteMembers_CS0618_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.DoesNotGenerateWarningsForObsoleteMembers_CS0618_Issue97.verified.txt
@@ -48,7 +48,7 @@
             {
                 global::MyEnum.First => nameof(global::MyEnum.First),
                 global::MyEnum.Second => nameof(global::MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.HandlesStringsWithQuotesAndSlashesInDescription.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/EnumGeneratorTests.HandlesStringsWithQuotesAndSlashesInDescription.verified.txt
@@ -53,7 +53,7 @@ namespace Test
                 global::Test.StringTesting.Backslash => nameof(global::Test.StringTesting.Backslash),
                 global::Test.StringTesting.BackslashLiteral => nameof(global::Test.StringTesting.BackslashLiteral),
                 global::Test.StringTesting.NewLine => nameof(global::Test.StringTesting.NewLine),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::Test.StringTesting value)
@@ -64,7 +64,7 @@ namespace Test
                 global::Test.StringTesting.Backslash => "Backslash \\",
                 global::Test.StringTesting.BackslashLiteral => "LiteralBackslash \\",
                 global::Test.StringTesting.NewLine => "New\nLine",
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         /// <summary>

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptExternalEnumToString.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptExternalEnumToString.verified.txt
@@ -143,7 +143,7 @@ namespace System
                 global::System.StringComparison.InvariantCultureIgnoreCase => nameof(global::System.StringComparison.InvariantCultureIgnoreCase),
                 global::System.StringComparison.Ordinal => nameof(global::System.StringComparison.Ordinal),
                 global::System.StringComparison.OrdinalIgnoreCase => nameof(global::System.StringComparison.OrdinalIgnoreCase),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::System.StringComparison value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptMultipleEnumsToString.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptMultipleEnumsToString.verified.txt
@@ -140,7 +140,7 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 global::MyTestNameSpace.MyEnum.Third => nameof(global::MyTestNameSpace.MyEnum.Third),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)
@@ -693,7 +693,7 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.AnotherEnum.First => nameof(global::MyTestNameSpace.AnotherEnum.First),
                 global::MyTestNameSpace.AnotherEnum.Second => nameof(global::MyTestNameSpace.AnotherEnum.Second),
                 global::MyTestNameSpace.AnotherEnum.Third => nameof(global::MyTestNameSpace.AnotherEnum.Third),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.AnotherEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptToString.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptToString.verified.txt
@@ -139,7 +139,7 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptToStringWhenCsharp11.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptToStringWhenCsharp11.verified.txt
@@ -139,7 +139,7 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptUsingInterceptableAttributeToString.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanInterceptUsingInterceptableAttributeToString.verified.txt
@@ -143,7 +143,7 @@ namespace System
                 global::System.StringComparison.InvariantCultureIgnoreCase => nameof(global::System.StringComparison.InvariantCultureIgnoreCase),
                 global::System.StringComparison.Ordinal => nameof(global::System.StringComparison.Ordinal),
                 global::System.StringComparison.OrdinalIgnoreCase => nameof(global::System.StringComparison.OrdinalIgnoreCase),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::System.StringComparison value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptEnumWithoutInterceptorPackage.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptEnumWithoutInterceptorPackage.verified.txt
@@ -139,7 +139,7 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptUsageInStringInterpolation.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptUsageInStringInterpolation.verified.txt
@@ -139,7 +139,7 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptUsageWithEnumDirectly.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.CanNotInterceptUsageWithEnumDirectly.verified.txt
@@ -139,7 +139,7 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotGenerateWarningsForUseOfObsoleteEnums_CS0612_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotGenerateWarningsForUseOfObsoleteEnums_CS0612_Issue97.verified.txt
@@ -48,7 +48,7 @@
             {
                 global::OtherEnum.First => nameof(global::OtherEnum.First),
                 global::OtherEnum.Second => nameof(global::OtherEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::OtherEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotGenerateWarningsForUseOfObsoleteEnums_CS0618_Issue97.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotGenerateWarningsForUseOfObsoleteEnums_CS0618_Issue97.verified.txt
@@ -48,7 +48,7 @@
             {
                 global::OtherEnum.First => nameof(global::OtherEnum.First),
                 global::OtherEnum.Second => nameof(global::OtherEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::OtherEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptEnumMarkedAsNotInterceptable.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptEnumMarkedAsNotInterceptable.verified.txt
@@ -140,7 +140,7 @@ namespace MyTestNameSpace
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
                 global::MyTestNameSpace.MyEnum.Third => nameof(global::MyTestNameSpace.MyEnum.Third),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptExternalEnumMarkedAsNotInterceptable.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptExternalEnumMarkedAsNotInterceptable.verified.txt
@@ -143,7 +143,7 @@ namespace System
                 global::System.StringComparison.InvariantCultureIgnoreCase => nameof(global::System.StringComparison.InvariantCultureIgnoreCase),
                 global::System.StringComparison.Ordinal => nameof(global::System.StringComparison.Ordinal),
                 global::System.StringComparison.OrdinalIgnoreCase => nameof(global::System.StringComparison.OrdinalIgnoreCase),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::System.StringComparison value)
@@ -750,7 +750,7 @@ namespace System
                 global::System.DateTimeKind.Unspecified => nameof(global::System.DateTimeKind.Unspecified),
                 global::System.DateTimeKind.Utc => nameof(global::System.DateTimeKind.Utc),
                 global::System.DateTimeKind.Local => nameof(global::System.DateTimeKind.Local),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::System.DateTimeKind value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptToStringWhenDisabled.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptToStringWhenDisabled.verified.txt
@@ -139,7 +139,7 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptToStringWhenOldCsharp.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/InterceptorTests.DoesNotInterceptToStringWhenOldCsharp.verified.txt
@@ -139,7 +139,7 @@ namespace MyTestNameSpace
             {
                 global::MyTestNameSpace.MyEnum.First => nameof(global::MyTestNameSpace.MyEnum.First),
                 global::MyTestNameSpace.MyEnum.Second => nameof(global::MyTestNameSpace.MyEnum.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::MyTestNameSpace.MyEnum value)

--- a/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesEnumCorrectly.verified.txt
+++ b/tests/NetEscapades.EnumGenerators.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesEnumCorrectly.verified.txt
@@ -50,7 +50,7 @@ namespace Something.Blah
             {
                 global::Something.Blah.ShortName.First => nameof(global::Something.Blah.ShortName.First),
                 global::Something.Blah.ShortName.Second => nameof(global::Something.Blah.ShortName.Second),
-                _ => value.ToString(),
+                _ => value.AsUnderlyingType().ToString(),
             };
 
         private static string ToStringFastWithMetadata(this global::Something.Blah.ShortName value)


### PR DESCRIPTION
When we have `switch`ed through all known values in `ToStringFast` a non-`[Flags]`-`Enum.ToString` will output a number - after again checking if a named value was used. We can short-circuit this by calling `value.AsUnderlyingType().ToString()` instead of just doing `value.ToString()`