### PR TITLE
Refactor integration tests to reduce duplication

### DIFF
--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInFooExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInFooExtensionsTests.cs
@@ -18,16 +18,16 @@ namespace NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests;
 #error Unknown integration tests
 #endif
 
-public class EnumInFooExtensionsTests : ExtensionTests<EnumInFoo>
+public class EnumInFooExtensionsTests : ExtensionTests<EnumInFoo, int, EnumInFooExtensionsTests>, ITestData<EnumInFoo>
 {
-    public static TheoryData<EnumInFoo> ValidEnumValues() => new()
+    public TheoryData<EnumInFoo> ValidEnumValues() => new()
     {
         EnumInFoo.First,
         EnumInFoo.Second,
         (EnumInFoo)3,
     };
 
-    public static TheoryData<string> ValuesToParse() => new()
+    public TheoryData<string> ValuesToParse() => new()
     {
         "First",
         "Second",
@@ -44,12 +44,17 @@ public class EnumInFooExtensionsTests : ExtensionTests<EnumInFoo>
         "Fifth",
     };
 
+    protected override string[] GetNames() => EnumInFooExtensions.GetNames();
+    protected override EnumInFoo[] GetValues() => EnumInFooExtensions.GetValues();
+    protected override int[] GetValuesAsUnderlyingType() => EnumInFooExtensions.GetValuesAsUnderlyingType();
+    protected override int AsUnderlyingValue(EnumInFoo value) => value.AsUnderlyingType();
+
     protected override string ToStringFast(EnumInFoo value) => value.ToStringFast();
     protected override string ToStringFast(EnumInFoo value, bool withMetadata) => value.ToStringFast(withMetadata);
     protected override bool IsDefined(EnumInFoo value) => EnumInFooExtensions.IsDefined(value);
-    protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => EnumInFooExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
+    protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => EnumInFooExtensions.IsDefined(name, allowMatchingMetadataAttribute);
 #if READONLYSPAN
-    protected override bool IsDefined(in ReadOnlySpan<char> name, bool allowMatchingMetadataAttribute) => EnumInFooExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
+    protected override bool IsDefined(in ReadOnlySpan<char> name, bool allowMatchingMetadataAttribute) => EnumInFooExtensions.IsDefined(name, allowMatchingMetadataAttribute);
 #endif
     protected override bool TryParse(string name, out EnumInFoo parsed, bool ignoreCase, bool allowMatchingMetadataAttribute)
         => EnumInFooExtensions.TryParse(name, out parsed, ignoreCase);
@@ -64,53 +69,4 @@ public class EnumInFooExtensionsTests : ExtensionTests<EnumInFoo>
     protected override EnumInFoo Parse(in ReadOnlySpan<char> name, bool ignoreCase, bool allowMatchingMetadataAttribute)
         => EnumInFooExtensions.Parse(name, ignoreCase);
 #endif
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFast(EnumInFoo value) => GeneratesToStringFastTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFastWithMetadata(EnumInFoo value) => GeneratesToStringFastWithMetadataTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesIsDefined(EnumInFoo value) => GeneratesIsDefinedTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingName(string name) => GeneratesIsDefinedTest(name, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParse(string name) => GeneratesTryParseTest(name, ignoreCase: false, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseUsingSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: false, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCase(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: false);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesAsUnderlyingType(EnumInFoo value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetValues() => GeneratesGetValuesTest(EnumInFooExtensions.GetValues());
-
-    [Fact]
-    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(EnumInFooExtensions.GetValuesAsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetNames() => base.GeneratesGetNamesTest(EnumInFooExtensions.GetNames());
 }

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInNamespaceExtensionsTests.cs
@@ -17,16 +17,16 @@ namespace NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests;
 #error Unknown integration tests
 #endif
 
-public class EnumInNamespaceExtensionsTests : ExtensionTests<EnumInNamespace>
+public class EnumInNamespaceExtensionsTests : ExtensionTests<EnumInNamespace, int, EnumInNamespaceExtensionsTests>, ITestData<EnumInNamespace>
 {
-    public static TheoryData<EnumInNamespace> ValidEnumValues() => new()
+    public TheoryData<EnumInNamespace> ValidEnumValues() => new()
     {
         EnumInNamespace.First,
         EnumInNamespace.Second,
         (EnumInNamespace)3,
     };
 
-    public static TheoryData<string> ValuesToParse() => new()
+    public TheoryData<string> ValuesToParse() => new()
     {
         "First",
         "Second",
@@ -43,12 +43,17 @@ public class EnumInNamespaceExtensionsTests : ExtensionTests<EnumInNamespace>
         "Fifth",
     };
 
+    protected override string[] GetNames() => EnumInNamespaceExtensions.GetNames();
+    protected override EnumInNamespace[] GetValues() => EnumInNamespaceExtensions.GetValues();
+    protected override int[] GetValuesAsUnderlyingType() => EnumInNamespaceExtensions.GetValuesAsUnderlyingType();
+    protected override int AsUnderlyingValue(EnumInNamespace value) => value.AsUnderlyingType();
+
     protected override string ToStringFast(EnumInNamespace value) => value.ToStringFast();
     protected override string ToStringFast(EnumInNamespace value, bool withMetadata) => value.ToStringFast(withMetadata);
     protected override bool IsDefined(EnumInNamespace value) => EnumInNamespaceExtensions.IsDefined(value);
-    protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => EnumInNamespaceExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
+    protected override bool IsDefined(string name, bool allowMatchingMetadataAttribute) => EnumInNamespaceExtensions.IsDefined(name, allowMatchingMetadataAttribute);
 #if READONLYSPAN
-    protected override bool IsDefined(in ReadOnlySpan<char> name, bool allowMatchingMetadataAttribute) => EnumInNamespaceExtensions.IsDefined(name, allowMatchingMetadataAttribute: false);
+    protected override bool IsDefined(in ReadOnlySpan<char> name, bool allowMatchingMetadataAttribute) => EnumInNamespaceExtensions.IsDefined(name, allowMatchingMetadataAttribute);
 #endif
     protected override bool TryParse(string name, out EnumInNamespace parsed, bool ignoreCase, bool allowMatchingMetadataAttribute)
         => EnumInNamespaceExtensions.TryParse(name, out parsed, ignoreCase);
@@ -63,53 +68,4 @@ public class EnumInNamespaceExtensionsTests : ExtensionTests<EnumInNamespace>
     protected override EnumInNamespace Parse(in ReadOnlySpan<char> name, bool ignoreCase, bool allowMatchingMetadataAttribute)
         => EnumInNamespaceExtensions.Parse(name, ignoreCase);
 #endif
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFast(EnumInNamespace value) => GeneratesToStringFastTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFastWithMetadata(EnumInNamespace value) => GeneratesToStringFastWithMetadataTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesIsDefined(EnumInNamespace value) => GeneratesIsDefinedTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingName(string name) => GeneratesIsDefinedTest(name, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParse(string name) => GeneratesTryParseTest(name, ignoreCase: false, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseUsingSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: false, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCase(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: false);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesAsUnderlyingType(EnumInNamespace value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetValues() => GeneratesGetValuesTest(EnumInNamespaceExtensions.GetValues());
-
-    [Fact]
-    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(EnumInNamespaceExtensions.GetValuesAsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetNames() => base.GeneratesGetNamesTest(EnumInNamespaceExtensions.GetNames());
 }

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDescriptionInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDescriptionInNamespaceExtensionsTests.cs
@@ -17,16 +17,16 @@ namespace NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests;
 #error Unknown integration tests
 #endif
 
-public class EnumWithDescriptionInNamespaceExtensionsTests : ExtensionTests<EnumWithDescriptionInNamespace>
+public class EnumWithDescriptionInNamespaceExtensionsTests : ExtensionTests<EnumWithDescriptionInNamespace, int, EnumWithDescriptionInNamespaceExtensionsTests>, ITestData<EnumWithDescriptionInNamespace>
 {
-    public static TheoryData<EnumWithDescriptionInNamespace> ValidEnumValues() => new()
+    public TheoryData<EnumWithDescriptionInNamespace> ValidEnumValues() => new()
     {
         EnumWithDescriptionInNamespace.First,
         EnumWithDescriptionInNamespace.Second,
         (EnumWithDescriptionInNamespace)3,
     };
 
-    public static TheoryData<string> ValuesToParse() => new()
+    public TheoryData<string> ValuesToParse() => new()
     {
         "First",
         "Second",
@@ -42,6 +42,11 @@ public class EnumWithDescriptionInNamespaceExtensionsTests : ExtensionTests<Enum
         "Fourth",
         "Fifth",
     };
+
+    protected override string[] GetNames() => EnumWithDescriptionInNamespaceExtensions.GetNames();
+    protected override EnumWithDescriptionInNamespace[] GetValues() => EnumWithDescriptionInNamespaceExtensions.GetValues();
+    protected override int[] GetValuesAsUnderlyingType() => EnumWithDescriptionInNamespaceExtensions.GetValuesAsUnderlyingType();
+    protected override int AsUnderlyingValue(EnumWithDescriptionInNamespace value) => value.AsUnderlyingType();
 
     protected override string ToStringFast(EnumWithDescriptionInNamespace value) => value.ToStringFast();
     protected override string ToStringFast(EnumWithDescriptionInNamespace value, bool withMetadata) => value.ToStringFast(withMetadata);
@@ -62,89 +67,4 @@ public class EnumWithDescriptionInNamespaceExtensionsTests : ExtensionTests<Enum
     protected override EnumWithDescriptionInNamespace Parse(in ReadOnlySpan<char> name, bool ignoreCase, bool allowMatchingMetadataAttribute)
         => EnumWithDescriptionInNamespaceExtensions.Parse(name, ignoreCase);
 #endif
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFast(EnumWithDescriptionInNamespace value) => GeneratesToStringFastTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFastWithMetadata(EnumWithDescriptionInNamespace value) => GeneratesToStringFastWithMetadataTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesIsDefined(EnumWithDescriptionInNamespace value) => GeneratesIsDefinedTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingName(string name) => GeneratesIsDefinedTest(name, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameallowMatchingMetadataAttribute(string name) => GeneratesIsDefinedTest(name, allowMatchingMetadataAttribute: true);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameallowMatchingMetadataAttributeAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: true);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParse(string name) => GeneratesTryParseTest(name, ignoreCase: false, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: false, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseallowMatchingMetadataAttribute(string name) => GeneratesTryParseTest(name, ignoreCase: false, allowMatchingMetadataAttribute: true);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseallowMatchingMetadataAttributeAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: false, allowMatchingMetadataAttribute: true);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCase(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCaseAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCaseallowMatchingMetadataAttribute(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: true);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCaseallowMatchingMetadataAttributeAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: true);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesAsUnderlyingType(EnumWithDescriptionInNamespace value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetValues() => GeneratesGetValuesTest(EnumWithDescriptionInNamespaceExtensions.GetValues());
-
-    [Fact]
-    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(EnumWithDescriptionInNamespaceExtensions.GetValuesAsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetNames() => base.GeneratesGetNamesTest(EnumWithDescriptionInNamespaceExtensions.GetNames());
 }

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDisplayNameInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDisplayNameInNamespaceExtensionsTests.cs
@@ -17,16 +17,16 @@ namespace NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests;
 #error Unknown integration tests
 #endif
 
-public class EnumWithDisplayNameInNamespaceExtensionsTests : ExtensionTests<EnumWithDisplayNameInNamespace>
+public class EnumWithDisplayNameInNamespaceExtensionsTests : ExtensionTests<EnumWithDisplayNameInNamespace, int, EnumWithDisplayNameInNamespaceExtensionsTests>, ITestData<EnumWithDisplayNameInNamespace>
 {
-    public static TheoryData<EnumWithDisplayNameInNamespace> ValidEnumValues() => new()
+    public TheoryData<EnumWithDisplayNameInNamespace> ValidEnumValues() => new()
     {
         EnumWithDisplayNameInNamespace.First,
         EnumWithDisplayNameInNamespace.Second,
         (EnumWithDisplayNameInNamespace)3,
     };
 
-    public static TheoryData<string> ValuesToParse() => new()
+    public TheoryData<string> ValuesToParse() => new()
     {
         "First",
         "Second",
@@ -42,6 +42,11 @@ public class EnumWithDisplayNameInNamespaceExtensionsTests : ExtensionTests<Enum
         "Fourth",
         "Fifth",
     };
+
+    protected override string[] GetNames() => EnumWithDisplayNameInNamespaceExtensions.GetNames();
+    protected override EnumWithDisplayNameInNamespace[] GetValues() => EnumWithDisplayNameInNamespaceExtensions.GetValues();
+    protected override int[] GetValuesAsUnderlyingType() => EnumWithDisplayNameInNamespaceExtensions.GetValuesAsUnderlyingType();
+    protected override int AsUnderlyingValue(EnumWithDisplayNameInNamespace value) => value.AsUnderlyingType();
 
     protected override string ToStringFast(EnumWithDisplayNameInNamespace value) => value.ToStringFast();
     protected override string ToStringFast(EnumWithDisplayNameInNamespace value, bool withMetadata) => value.ToStringFast(withMetadata);
@@ -62,88 +67,4 @@ public class EnumWithDisplayNameInNamespaceExtensionsTests : ExtensionTests<Enum
     protected override EnumWithDisplayNameInNamespace Parse(in ReadOnlySpan<char> name, bool ignoreCase, bool allowMatchingMetadataAttribute)
         => EnumWithDisplayNameInNamespaceExtensions.Parse(name, ignoreCase);
 #endif
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFast(EnumWithDisplayNameInNamespace value) => GeneratesToStringFastTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFastWithMetadata(EnumWithDisplayNameInNamespace value) => GeneratesToStringFastWithMetadataTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesIsDefined(EnumWithDisplayNameInNamespace value) => GeneratesIsDefinedTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingName(string name) => GeneratesIsDefinedTest(name, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameallowMatchingMetadataAttribute(string name) => GeneratesIsDefinedTest(name, allowMatchingMetadataAttribute: true);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameallowMatchingMetadataAttributeAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: true);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParse(string name) => GeneratesTryParseTest(name, ignoreCase: false, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: false, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseallowMatchingMetadataAttribute(string name) => GeneratesTryParseTest(name, ignoreCase: false, allowMatchingMetadataAttribute: true);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseallowMatchingMetadataAttributeAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: false, allowMatchingMetadataAttribute: true);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCase(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCaseAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCaseallowMatchingMetadataAttribute(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: true);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCaseallowMatchingMetadataAttributeAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: true);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesAsUnderlyingType(EnumWithDisplayNameInNamespace value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetValues() => GeneratesGetValuesTest(EnumWithDisplayNameInNamespaceExtensions.GetValues());
-
-    [Fact]
-    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(EnumWithDisplayNameInNamespaceExtensions.GetValuesAsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetNames() => base.GeneratesGetNamesTest(EnumWithDisplayNameInNamespaceExtensions.GetNames());
 }

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithSameDisplayNameExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithSameDisplayNameExtensionsTests.cs
@@ -17,16 +17,16 @@ namespace NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests;
 #error Unknown integration tests
 #endif
 
-public class EnumWithSameDisplayNameExtensionsTests : ExtensionTests<EnumWithSameDisplayName>
+public class EnumWithSameDisplayNameExtensionsTests : ExtensionTests<EnumWithSameDisplayName, int, EnumWithSameDisplayNameExtensionsTests>, ITestData<EnumWithSameDisplayName>
 {
-    public static TheoryData<EnumWithSameDisplayName> ValidEnumValues() => new()
+    public TheoryData<EnumWithSameDisplayName> ValidEnumValues() => new()
     {
         EnumWithSameDisplayName.First,
         EnumWithSameDisplayName.Second,
         (EnumWithSameDisplayName)3,
     };
 
-    public static TheoryData<string> ValuesToParse() => new()
+    public TheoryData<string> ValuesToParse() => new()
     {
         "First",
         "Second",
@@ -42,6 +42,11 @@ public class EnumWithSameDisplayNameExtensionsTests : ExtensionTests<EnumWithSam
         "Fourth",
         "Fifth",
     };
+
+    protected override string[] GetNames() => EnumWithSameDisplayNameExtensions.GetNames();
+    protected override EnumWithSameDisplayName[] GetValues() => EnumWithSameDisplayNameExtensions.GetValues();
+    protected override int[] GetValuesAsUnderlyingType() => EnumWithSameDisplayNameExtensions.GetValuesAsUnderlyingType();
+    protected override int AsUnderlyingValue(EnumWithSameDisplayName value) => value.AsUnderlyingType();
 
     protected override string ToStringFast(EnumWithSameDisplayName value) => value.ToStringFast();
     protected override string ToStringFast(EnumWithSameDisplayName value, bool withMetadata) => value.ToStringFast(withMetadata);
@@ -62,88 +67,4 @@ public class EnumWithSameDisplayNameExtensionsTests : ExtensionTests<EnumWithSam
     protected override EnumWithSameDisplayName Parse(in ReadOnlySpan<char> name, bool ignoreCase, bool allowMatchingMetadataAttribute)
         => EnumWithSameDisplayNameExtensions.Parse(name, ignoreCase);
 #endif
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFast(EnumWithSameDisplayName value) => GeneratesToStringFastTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFastWithMetadata(EnumWithSameDisplayName value) => GeneratesToStringFastWithMetadataTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesIsDefined(EnumWithSameDisplayName value) => GeneratesIsDefinedTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingName(string name) => GeneratesIsDefinedTest(name, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameallowMatchingMetadataAttribute(string name) => GeneratesIsDefinedTest(name, allowMatchingMetadataAttribute: true);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameallowMatchingMetadataAttributeAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: true);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParse(string name) => GeneratesTryParseTest(name, ignoreCase: false, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: false, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseallowMatchingMetadataAttribute(string name) => GeneratesTryParseTest(name, ignoreCase: false, allowMatchingMetadataAttribute: true);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseallowMatchingMetadataAttributeAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: false, allowMatchingMetadataAttribute: true);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCase(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCaseAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCaseallowMatchingMetadataAttribute(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: true);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCaseallowMatchingMetadataAttributeAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: true);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesAsUnderlyingType(EnumWithSameDisplayName value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetValues() => GeneratesGetValuesTest(EnumWithSameDisplayNameExtensions.GetValues());
-
-    [Fact]
-    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(EnumWithSameDisplayNameExtensions.GetValuesAsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetNames() => base.GeneratesGetNamesTest(EnumWithSameDisplayNameExtensions.GetNames());
 }

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/ExternalEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/ExternalEnumExtensionsTests.cs
@@ -19,16 +19,16 @@ namespace NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests;
 #error Unknown integration tests
 #endif
 
-public class ExternalEnumExtensionsTests : ExtensionTests<DateTimeKind>
+public class ExternalEnumExtensionsTests : ExtensionTests<DateTimeKind, int, ExternalEnumExtensionsTests>, ITestData<DateTimeKind>
 {
-    public static TheoryData<DateTimeKind> ValidEnumValues() => new()
+    public TheoryData<DateTimeKind> ValidEnumValues() => new()
     {
         DateTimeKind.Unspecified,
         DateTimeKind.Utc,
         (DateTimeKind)3, // not actually valid
     };
 
-    public static TheoryData<string> ValuesToParse() => new()
+    public TheoryData<string> ValuesToParse() => new()
     {
         "Unspecified",
         "Utc",
@@ -45,6 +45,11 @@ public class ExternalEnumExtensionsTests : ExtensionTests<DateTimeKind>
         "Fourth",
         "Fifth",
     };
+
+    protected override string[] GetNames() => DateTimeKindExtensions.GetNames();
+    protected override DateTimeKind[] GetValues() => DateTimeKindExtensions.GetValues();
+    protected override int[] GetValuesAsUnderlyingType() => DateTimeKindExtensions.GetValuesAsUnderlyingType();
+    protected override int AsUnderlyingValue(DateTimeKind value) => value.AsUnderlyingType();
 
     protected override string ToStringFast(DateTimeKind value) => value.ToStringFast();
     protected override string ToStringFast(DateTimeKind value, bool withMetadata) => value.ToStringFast(withMetadata);
@@ -65,52 +70,4 @@ public class ExternalEnumExtensionsTests : ExtensionTests<DateTimeKind>
     protected override DateTimeKind Parse(in ReadOnlySpan<char> name, bool ignoreCase, bool allowMatchingMetadataAttribute)
         => DateTimeKindExtensions.Parse(name, ignoreCase);
 #endif
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFast(DateTimeKind value) => GeneratesToStringFastTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFastWithMetadata(DateTimeKind value) => GeneratesToStringFastWithMetadataTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesIsDefined(DateTimeKind value) => GeneratesIsDefinedTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingName(string name) => GeneratesIsDefinedTest(name, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParse(string name) => GeneratesTryParseTest(name, ignoreCase: false, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseUsingSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: false, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCase(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: false);
-
-    // Ignoring order in these
-    [Fact]
-    public void GeneratesGetValues()
-        => DateTimeKindExtensions.GetValues()
-            .Should()
-            .BeEquivalentTo((DateTimeKind[])Enum.GetValues(typeof(DateTimeKind)));
-
-    [Fact]
-    public void GeneratesGetNames()
-        => DateTimeKindExtensions.GetNames()
-            .Should()
-            .BeEquivalentTo(Enum.GetNames(typeof(DateTimeKind)));
 }

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/ExternalFlagsEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/ExternalFlagsEnumExtensionsTests.cs
@@ -21,9 +21,9 @@ namespace NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests;
 #error Unknown integration tests
 #endif
 
-public class ExternalFileShareExtensionsTests : ExtensionTests<FileShare>
+public class ExternalFileShareExtensionsTests : ExtensionTests<FileShare, int, ExternalFileShareExtensionsTests>, ITestData<FileShare>
 {
-    public static TheoryData<FileShare> ValidEnumValues() => new()
+    public TheoryData<FileShare> ValidEnumValues() => new()
     {
         FileShare.Read,
         FileShare.Write,
@@ -31,7 +31,7 @@ public class ExternalFileShareExtensionsTests : ExtensionTests<FileShare>
         (FileShare)3,
     };
 
-    public static TheoryData<string> ValuesToParse() => new()
+    public TheoryData<string> ValuesToParse() => new()
     {
         "Read",
         "Write",
@@ -47,6 +47,11 @@ public class ExternalFileShareExtensionsTests : ExtensionTests<FileShare>
         "Fourth",
         "Fifth",
     };
+
+    protected override string[] GetNames() => FileShareExtensions.GetNames();
+    protected override FileShare[] GetValues() => FileShareExtensions.GetValues();
+    protected override int[] GetValuesAsUnderlyingType() => FileShareExtensions.GetValuesAsUnderlyingType();
+    protected override int AsUnderlyingValue(FileShare value) => value.AsUnderlyingType();
 
     protected override string ToStringFast(FileShare value) => value.ToStringFast();
     protected override string ToStringFast(FileShare value, bool withMetadata) => value.ToStringFast(withMetadata);
@@ -66,33 +71,6 @@ public class ExternalFileShareExtensionsTests : ExtensionTests<FileShare>
 #if READONLYSPAN
     protected override FileShare Parse(in ReadOnlySpan<char> name, bool ignoreCase, bool allowMatchingMetadataAttribute)
         => FileShareExtensions.Parse(name, ignoreCase);
-#endif
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="value"></param>
-    /// <remarks>If the underlying value of <paramref name="flag"/> is zero, the method returns true.
-    /// This is consistent with the behaviour of <see cref=""Enum.HasFlag(Enum)""></remarks>
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFast(FileShare value) => GeneratesToStringFastTest(value);
- 
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFastWithMetadata(FileShare value) => GeneratesToStringFastWithMetadataTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesIsDefined(FileShare value) => GeneratesIsDefinedTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingName(string name) => GeneratesIsDefinedTest(name, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: false);
 #endif
 
     public static IEnumerable<object[]> AllFlags()
@@ -121,37 +99,4 @@ public class ExternalFileShareExtensionsTests : ExtensionTests<FileShare>
 
         isDefined.Should().Be(value.HasFlag(flag));
     }
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParse(string name) => GeneratesTryParseTest(name, ignoreCase: false, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: false, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCase(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCaseAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: false);
-#endif
-
-    // Ignoring order in these
-    [Fact]
-    public void GeneratesGetValues()
-        => FileShareExtensions.GetValues()
-            .Should()
-            .BeEquivalentTo((FileShare[])Enum.GetValues(typeof(FileShare)));
-
-    [Fact]
-    public void GeneratesGetNames()
-        => FileShareExtensions.GetNames()
-            .Should()
-            .BeEquivalentTo(Enum.GetNames(typeof(FileShare)));
 }

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/FlagsEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/FlagsEnumExtensionsTests.cs
@@ -20,9 +20,9 @@ namespace NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests;
 #error Unknown integration tests
 #endif
 
-public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum>
+public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum, int, FlagsEnumExtensionsTests>, ITestData<FlagsEnum>
 {
-    public static TheoryData<FlagsEnum> ValidEnumValues() => new()
+    public TheoryData<FlagsEnum> ValidEnumValues() => new()
     {
         FlagsEnum.First,
         FlagsEnum.Second,
@@ -30,7 +30,7 @@ public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum>
         (FlagsEnum)3,
     };
 
-    public static TheoryData<string> ValuesToParse() => new()
+    public TheoryData<string> ValuesToParse() => new()
     {
         "First",
         "Second",
@@ -46,6 +46,11 @@ public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum>
         "Fourth",
         "Fifth",
     };
+
+    protected override string[] GetNames() => FlagsEnumExtensions.GetNames();
+    protected override FlagsEnum[] GetValues() => FlagsEnumExtensions.GetValues();
+    protected override int[] GetValuesAsUnderlyingType() => FlagsEnumExtensions.GetValuesAsUnderlyingType();
+    protected override int AsUnderlyingValue(FlagsEnum value) => value.AsUnderlyingType();
 
     protected override string ToStringFast(FlagsEnum value) => value.ToStringFast();
     protected override string ToStringFast(FlagsEnum value, bool withMetadata) => value.ToStringFast(withMetadata);
@@ -65,34 +70,6 @@ public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum>
 #if READONLYSPAN
     protected override FlagsEnum Parse(in ReadOnlySpan<char> name, bool ignoreCase, bool allowMatchingMetadataAttribute)
         => FlagsEnumExtensions.Parse(name, ignoreCase);
-#endif
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="value"></param>
-    /// <remarks>If the underlying value of <paramref name="flag"/> is zero, the method returns true.
-    /// This is consistent with the behaviour of <see cref=""Enum.HasFlag(Enum)""></remarks>
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFast(FlagsEnum value) => GeneratesToStringFastTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFastWithMetadata(FlagsEnum value) => GeneratesToStringFastWithMetadataTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesIsDefined(FlagsEnum value) => GeneratesIsDefinedTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingName(string name) => GeneratesIsDefinedTest(name, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: false);
 #endif
 
     public static IEnumerable<object[]> AllFlags()
@@ -121,37 +98,4 @@ public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum>
 
         isDefined.Should().Be(value.HasFlag(flag));
     }
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParse(string name) => GeneratesTryParseTest(name, ignoreCase: false, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: false, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCase(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCaseAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesAsUnderlyingType(FlagsEnum value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetValues() => GeneratesGetValuesTest(FlagsEnumExtensions.GetValues());
-
-    [Fact]
-    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(FlagsEnumExtensions.GetValuesAsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetNames() => base.GeneratesGetNamesTest(FlagsEnumExtensions.GetNames());
 }

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/LongEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/LongEnumExtensionsTests.cs
@@ -17,16 +17,16 @@ namespace NetEscapades.EnumGenerators.Nuget.Interceptors.IntegrationTests;
 #error Unknown integration tests
 #endif
 
-public class LongEnumExtensionsTests : ExtensionTests<LongEnum>
+public class LongEnumExtensionsTests : ExtensionTests<LongEnum, long, LongEnumExtensionsTests>, ITestData<LongEnum>
 {
-    public static TheoryData<LongEnum> ValidEnumValues() => new()
+    public TheoryData<LongEnum> ValidEnumValues() => new()
     {
         LongEnum.First,
         LongEnum.Second,
         (LongEnum)3,
     };
 
-    public static TheoryData<string> ValuesToParse() => new()
+    public TheoryData<string> ValuesToParse() => new()
     {
         "First",
         "Second",
@@ -42,6 +42,11 @@ public class LongEnumExtensionsTests : ExtensionTests<LongEnum>
         "Fourth",
         "Fifth",
     };
+
+    protected override string[] GetNames() => LongEnumExtensions.GetNames();
+    protected override LongEnum[] GetValues() => LongEnumExtensions.GetValues();
+    protected override long[] GetValuesAsUnderlyingType() => LongEnumExtensions.GetValuesAsUnderlyingType();
+    protected override long AsUnderlyingValue(LongEnum value) => value.AsUnderlyingType();
 
     protected override string ToStringFast(LongEnum value) => value.ToStringFast();
     protected override string ToStringFast(LongEnum value, bool withMetadata) => value.ToStringFast(withMetadata);
@@ -62,59 +67,4 @@ public class LongEnumExtensionsTests : ExtensionTests<LongEnum>
     protected override LongEnum Parse(in ReadOnlySpan<char> name, bool ignoreCase, bool allowMatchingMetadataAttribute)
         => LongEnumExtensions.Parse(name, ignoreCase);
 #endif
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFast(LongEnum value) => GeneratesToStringFastTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesToStringFastWithMetadata(LongEnum value) => GeneratesToStringFastWithMetadataTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesIsDefined(LongEnum value) => GeneratesIsDefinedTest(value);
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingName(string name) => GeneratesIsDefinedTest(name, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesIsDefinedUsingNameAsSpan(string name) => GeneratesIsDefinedTest(name.AsSpan(), allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParse(string name) => GeneratesTryParseTest(name, ignoreCase:false, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseAsSpan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: false, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCase(string name) => GeneratesTryParseTest(name, ignoreCase: true, allowMatchingMetadataAttribute: false);
-
-#if READONLYSPAN
-    [Theory]
-    [MemberData(nameof(ValuesToParse))]
-    public void GeneratesTryParseIgnoreCaseAsAspan(string name) => GeneratesTryParseTest(name.AsSpan(), ignoreCase: true, allowMatchingMetadataAttribute: false);
-#endif
-
-    [Theory]
-    [MemberData(nameof(ValidEnumValues))]
-    public void GeneratesAsUnderlyingType(LongEnum value) => GeneratesAsUnderlyingTypeTest(value, value.AsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetValues() => GeneratesGetValuesTest(LongEnumExtensions.GetValues());
-
-    [Fact]
-    public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(LongEnumExtensions.GetValuesAsUnderlyingType());
-
-    [Fact]
-    public void GeneratesGetNames() => base.GeneratesGetNamesTest(LongEnumExtensions.GetNames());
 }


### PR DESCRIPTION
Instead of defining the tests in each of the derived types, define it in the base class 