### PR TITLE
Create an analyzer that explicitly flags naming clash for extensions

### DIFF
--- a/src/NetEscapades.EnumGenerators/Diagnostics/DuplicateExtensionClassAnalyzer.cs
+++ b/src/NetEscapades.EnumGenerators/Diagnostics/DuplicateExtensionClassAnalyzer.cs
@@ -1,0 +1,104 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace NetEscapades.EnumGenerators.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class DuplicateExtensionClassAnalyzer: DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "NEEG001";
+    private static readonly DiagnosticDescriptor Rule = new(
+#pragma warning disable RS2008 // Enable Analyzer Release Tracking
+        id: DiagnosticId,
+#pragma warning restore RS2008
+        title: "Duplicate generated extension class",
+        messageFormat:
+        "The generated extension class '{1}.{2}' for enum '{0}' clashes with other generated extension classes. Use ExtensionClassNamespace or ExtensionClassName to specify a unique combination.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        customTags: "CompilationEnd");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        // Analyze symbols instead of syntax
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+#pragma warning disable RS1012 // 'startContext' does not register any analyzer actions - false positive
+        context.RegisterCompilationStartAction(startContext =>
+#pragma warning restore RS1012 // 'startContext' does not register any analyzer actions - false positive
+        {
+            var enumMap = new ConcurrentDictionary<Tuple<string, string>, List<Tuple<Location, string>>>();
+
+            startContext.RegisterSymbolAction(symbolContext =>
+            {
+                var ct = symbolContext.CancellationToken;
+                var enumSymbol = (INamedTypeSymbol)symbolContext.Symbol;
+                if (enumSymbol.TypeKind != TypeKind.Enum)
+                {
+                    return;
+                }
+
+                Location? location = null;
+                string? ns = null;
+                string? name = null;
+                foreach (var attributeData in enumSymbol.GetAttributes())
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    if (EnumGenerator.TryGetExtensionAttributeDetails(attributeData, ref ns, ref name))
+                    {
+                        location = attributeData.ApplicationSyntaxReference?.GetSyntax(ct).GetLocation()
+                                   ?? enumSymbol.Locations[0];
+                        break;
+                    }
+                }
+
+                if (location is null || ct.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                // we have the attribute, get the calculated names
+                ns ??= EnumGenerator.GetEnumExtensionNamespace(enumSymbol); 
+                name ??= EnumGenerator.GetEnumExtensionName(enumSymbol);
+
+                enumMap.AddOrUpdate(new(ns, name),
+                    _ => [new(location, enumSymbol.Name)],
+                    (_, list) =>
+                    {
+                        list.Add(new(location, enumSymbol.Name));
+                        return list;
+                    });
+            }, SymbolKind.NamedType);
+
+            startContext.RegisterCompilationEndAction(endContext =>
+            {
+                foreach (var kvp in enumMap)
+                {
+                    var duplicates = kvp.Value;
+                    if (duplicates.Count > 1)
+                    {
+                        foreach (var symbol in duplicates)
+                        {
+                            var ns = kvp.Key.Item1;
+                            var name = kvp.Key.Item2;
+                            var diag = Diagnostic.Create(Rule, symbol.Item1,
+                                symbol.Item2, ns, name);
+                            endContext.ReportDiagnostic(diag);
+                        }
+                    }
+                }
+            });
+        });
+    }
+}

--- a/src/NetEscapades.EnumGenerators/NetEscapades.EnumGenerators.csproj
+++ b/src/NetEscapades.EnumGenerators/NetEscapades.EnumGenerators.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" PrivateAssets="all" />
     <PackageReference Include="Polyfill" Version="1.32.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
+++ b/src/NetEscapades.EnumGenerators/SourceGenerationHelper.cs
@@ -20,10 +20,8 @@ public static class SourceGenerationHelper
 
         """;
 
-    public const string Attribute =
-        $$"""
-        {{Header}}
-        #if NETESCAPADES_ENUMGENERATORS_EMBED_ATTRIBUTES
+    public const string AttributeDefinitions =
+        """
         namespace NetEscapades.EnumGenerators
         {
             /// <summary>
@@ -97,6 +95,13 @@ public static class SourceGenerationHelper
                 public bool IsInterceptable { get; set; } = true;
             }
         }
+        """;
+
+    public const string Attribute =
+        $$"""
+        {{Header}}
+        #if NETESCAPADES_ENUMGENERATORS_EMBED_ATTRIBUTES
+        {{AttributeDefinitions}}
         #endif
 
         """;

--- a/tests/NetEscapades.EnumGenerators.Tests/DuplicateExtensionClassAnalyzerTests.cs
+++ b/tests/NetEscapades.EnumGenerators.Tests/DuplicateExtensionClassAnalyzerTests.cs
@@ -1,0 +1,300 @@
+using System.Threading.Tasks;
+using NetEscapades.EnumGenerators.Diagnostics;
+using Xunit;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    NetEscapades.EnumGenerators.Diagnostics.DuplicateExtensionClassAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace NetEscapades.EnumGenerators.Tests;
+
+public class DuplicateExtensionClassAnalyzerTests
+{
+    private const string DiagnosticId = DuplicateExtensionClassAnalyzer.DiagnosticId;
+
+    // No diagnostics expected to show up
+    [Fact]
+    public async Task EmptySourceShouldNotHaveDiagnostics()
+    {
+        var test = string.Empty;
+        await Verifier.VerifyAnalyzerAsync(test);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("""(ExtensionClassName = "SomeExtension")""")]
+    [InlineData("""(ExtensionClassNamespace = "SomeNamespace")""")]
+    [InlineData("""(ExtensionClassName = "SomeExtension", ExtensionClassNamespace = "SomeNamespace")""")]
+    public async Task SingleEnumShouldNotHaveDiagnostics(string args)
+    {
+        var test = GetTestCode(
+            $$"""
+              [EnumExtensions{{args}}]
+              public enum TestEnum
+              {
+                  First,
+                  Second,
+              }
+              """);
+        await Verifier.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task MultipleEnumsInDifferentNamespaceShouldNotHaveDiagnostics()
+    {
+        var test = GetTestCode(
+            $$"""
+              namespace ConsoleApplication1
+              {
+                  [EnumExtensions]
+                  public enum TestEnum
+                  {
+                      First,
+                      Second,
+                  }
+              }
+              namespace ConsoleApplication2
+              {
+                  [EnumExtensions]
+                  public enum TestEnum
+                  {
+                      First,
+                      Second,
+                  }
+              }
+              """);
+
+        await Verifier.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task MultipleEnumsWithDifferentNamesShouldNotHaveDiagnostics()
+    {
+        var test = GetTestCode(
+            $$"""
+              namespace ConsoleApplication1
+              {
+                  [EnumExtensions]
+                  public enum TestEnum
+                  {
+                      First,
+                      Second,
+                  }
+
+                  [EnumExtensions]
+                  public enum TestEnum2
+                  {
+                      First,
+                      Second,
+                  }
+              }
+
+              
+              """);
+        await Verifier.VerifyAnalyzerAsync(test);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("""(ExtensionClassName = "SomeExtension")""")]
+    [InlineData("""(ExtensionClassNamespace = "SomeNamespace")""")]
+    [InlineData("""(ExtensionClassName = "SomeExtension", ExtensionClassNamespace = "SomeNamespace")""")]
+    public async Task MultipleEnumsWithMultipleValuesShouldNotHaveDiagnostics(string args)
+    {
+        var test = GetTestCode(
+            $$"""
+              namespace ConsoleApplication1
+              {
+                  [{|#0:EnumExtensions|}]
+                  public enum TestEnum1
+                  {
+                      First,
+                      Second,
+                  }
+
+                  [{|#1:EnumExtensions{{args}}|}]
+                  public enum TestEnum
+                  {
+                      First,
+                      Second,
+                  }
+              }
+              """);
+
+        // Don't bother to validate message 
+        await Verifier.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ShouldFlagEnumsThatGenerateTheSameExtensionMethod()
+    {
+        var test = GetTestCode(
+            $$"""
+              namespace ConsoleApplication1
+              {
+                  [{|#0:EnumExtensions|}]
+                  public enum TestEnum
+                  {
+                      First,
+                      Second,
+                  }
+
+                  [{|#1:EnumExtensions(ExtensionClassName = "TestEnumExtensions")|}]
+                  public enum TestEnum2
+                  {
+                      First,
+                      Second,
+                  }
+              }
+              """);
+
+        // Don't bother to validate message 
+        var expected1 = Verifier.Diagnostic(DiagnosticId).WithLocation(0).WithMessage(null);
+        var expected2 = Verifier.Diagnostic(DiagnosticId).WithLocation(1).WithMessage(null);
+        await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("""(ExtensionClassName = "SomeExtension")""")]
+    [InlineData("""(ExtensionClassNamespace = "SomeNamespace")""")]
+    [InlineData("""(ExtensionClassName = "SomeExtension", ExtensionClassNamespace = "SomeNamespace")""")]
+    public async Task ShouldFlagEnumsThatGenerateTheSameExtensionMethodDueToNestedClass(string args)
+    {
+        var test = GetTestCode(
+            $$"""
+              namespace ConsoleApplication1
+              {
+                  [{|#0:EnumExtensions{{args}}|}]
+                  public enum TestEnum
+                  {
+                      First,
+                      Second,
+                  }
+
+                  public class Nested
+                  {
+                      [{|#1:EnumExtensions{{args}}|}]
+                      public enum TestEnum
+                      {
+                          First,
+                          Second,
+                      }
+                  }
+              }
+              """);
+
+        // Don't bother to validate message 
+        var expected1 = Verifier.Diagnostic(DiagnosticId).WithLocation(0).WithMessage(null);
+        var expected2 = Verifier.Diagnostic(DiagnosticId).WithLocation(1).WithMessage(null);
+        await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);
+    }
+
+    [Fact]
+    public async Task ShouldFlagEnumsThatGenerateTheSameExtensionMethodDueToNamespaceClash()
+    {
+        var test = GetTestCode(
+            $$"""
+              namespace ConsoleApplication1
+              {
+                  [{|#0:EnumExtensions|}]
+                  public enum TestEnum1
+                  {
+                      First,
+                      Second,
+                  }
+              }
+
+              namespace SomeNamespace
+              {
+                  [{|#1:EnumExtensions(ExtensionClassNamespace = "ConsoleApplication1")|}]
+                  public enum TestEnum1
+                  {
+                      First,
+                      Second,
+                  }
+              }
+              """);
+
+        // Don't bother to validate message 
+        var expected1 = Verifier.Diagnostic(DiagnosticId).WithLocation(0).WithMessage(null);
+        var expected2 = Verifier.Diagnostic(DiagnosticId).WithLocation(1).WithMessage(null);
+        await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);
+    }
+
+    [Fact]
+    public async Task ShouldFlagEnumsThatGenerateTheSameExtensionMethodDueToNameClash()
+    {
+        var test = GetTestCode(
+            $$"""
+              namespace ConsoleApplication1
+              {
+                  [{|#0:EnumExtensions|}]
+                  public enum TestEnum1
+                  {
+                      First,
+                      Second,
+                  }
+
+                  [{|#1:EnumExtensions(ExtensionClassName = "TestEnum1Extensions")|}]
+                  public enum TestEnum2
+                  {
+                      First,
+                      Second,
+                  }
+              }
+              """);
+
+        // Don't bother to validate message 
+        var expected1 = Verifier.Diagnostic(DiagnosticId).WithLocation(0).WithMessage(null);
+        var expected2 = Verifier.Diagnostic(DiagnosticId).WithLocation(1).WithMessage(null);
+        await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);
+    }
+    [Fact]
+    public async Task ShouldFlagEnumsThatGenerateTheSameExtensionMethodDueToNameAndNamespaceClash()
+    {
+        var test = GetTestCode(
+            $$"""
+              namespace ConsoleApplication1
+              {
+                  [{|#0:EnumExtensions|}]
+                  public enum TestEnum1
+                  {
+                      First,
+                      Second,
+                  }
+              }
+
+              namespace ConsoleApplication2
+              {
+                  [{|#1:EnumExtensions(ExtensionClassName = "TestEnum1Extensions", ExtensionClassNamespace = "ConsoleApplication1")|}]
+                  public enum TestEnum2
+                  {
+                      First,
+                      Second,
+                  }
+              }
+              """);
+
+        // Don't bother to validate message 
+        var expected1 = Verifier.Diagnostic(DiagnosticId).WithLocation(0).WithMessage(null);
+        var expected2 = Verifier.Diagnostic(DiagnosticId).WithLocation(1).WithMessage(null);
+        await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);
+    }
+
+    private static string GetTestCode(string testFragment)
+        => $$"""
+
+                 using System;
+                 using System.Collections.Generic;
+                 using System.Linq;
+                 using System.Text;
+                 using System.Threading;
+                 using System.Threading.Tasks;
+                 using System.Diagnostics;
+                 using NetEscapades.EnumGenerators;
+
+                 {{testFragment}}
+
+             {{SourceGenerationHelper.AttributeDefinitions}}
+             """;
+}

--- a/tests/NetEscapades.EnumGenerators.Tests/NetEscapades.EnumGenerators.Tests.csproj
+++ b/tests/NetEscapades.EnumGenerators.Tests/NetEscapades.EnumGenerators.Tests.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Verify.Xunit" Version="14.3.0" />


### PR DESCRIPTION
Currently, you can generate extension types that result in the same extension class being generated, which causes clashes. For example, the following generates `SomeNamespace.MyEnumExtensions` twice, one for each `enum`:

```csharp
namespace SomeNamespace;

[EnumExtensions]
public enum MyEnum
{
    One,
    Two
}

public class Nested
{
    [EnumExtensions]
    public enum MyEnum
    {
        One,
        Two
    }
}
```

_Ideally_ we would disambiguate by generating `SomeNamespace.Nested.MyEnumExtensions` as a nested class, but extension method classes can't be nested classes. Another option would be to include the class name in the generated namespace, but then there's _another_ issue that can generate clashes. Ultimately, it _would_ be possible to generate an extension method something like `Nested_MyEnum`, but there's always ways to get clashes (or you have to generate something really ugly). Plus it would be a breaking change.

Given that these types of clashes are going to be rare, this PR just adds an analyzer `NEEG001` that flags the fact there's a clash on the `[EnumExtensions]` attribute directly.

This isn't strictly necessary, because generating duplicate extension classes results in a _lot_ of compiler errors, but having an analyzer will hopefully make it more obvious exactly what's happened.