### PR TITLE
Set default for EnumGenerator_ForceExtensionMembers to false

### DIFF
--- a/src/NetEscapades.EnumGenerators/NetEscapades.EnumGenerators.props
+++ b/src/NetEscapades.EnumGenerators/NetEscapades.EnumGenerators.props
@@ -1,7 +1,7 @@
 <Project>  
   <PropertyGroup>
     <EnumGenerator_EnumMetadataSource Condition="$(EnumGenerator_EnumMetadataSource) == ''">EnumMemberAttribute</EnumGenerator_EnumMetadataSource>
-    <EnumGenerator_ForceExtensionMembers Condition="$(EnumGenerator_ForceExtensionMembers) == ''">true</EnumGenerator_ForceExtensionMembers>
+    <EnumGenerator_ForceExtensionMembers Condition="$(EnumGenerator_ForceExtensionMembers) == ''">false</EnumGenerator_ForceExtensionMembers>
   </PropertyGroup>
   <ItemGroup>
     <CompilerVisibleProperty Include="EnumGenerator_EnumMetadataSource" />


### PR DESCRIPTION
Looks like the default value of EnumGenerator_ForceExtensionMembers is true.
Assuming it was meant to be false

fixes #171