### PR TITLE
Change how the usage analyzers are enabled to use an `EnumGenerator_EnableUsageAnalyzers` MSBuild property instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,14 +285,15 @@ _NetEscapades.EnumGenerators_ includes optional analyzers that encourage the use
 
 ### Enabling the analyzers
 
-The usage analyzers are disabled by default. To enable them, [add a `.globalconfig` file](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig) to your project with the following content:
+The usage analyzers are disabled by default. To enable them, set the `EnumGenerator_EnableUsageAnalyzers` MSBuild property to `true` in your project:
 
-```ini
-is_global = true
-netescapades.enumgenerators.usage_analyzers.enable = true
+```xml
+<PropertyGroup>
+  <EnumGenerator_EnableUsageAnalyzers>true</EnumGenerator_EnableUsageAnalyzers>
+</PropertyGroup>
 ```
 
-Your project should automatically detect this configuration file, and enable all the usage analyzers with the default severity of `Warning`.
+After adding this configuration, the analyzers in your project should be enabled with the default severity of `Warning`.
 
 ### Configuring analyzer severity (optional)
 

--- a/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/GetNamesAnalyzer.cs
+++ b/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/GetNamesAnalyzer.cs
@@ -21,7 +21,7 @@ public class GetNamesAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        => ImmutableArray.Create(Rule, UsageAnalyzerConfig.ConfigDescriptor);
+        => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
     {

--- a/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/GetValuesAnalyzer.cs
+++ b/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/GetValuesAnalyzer.cs
@@ -21,7 +21,7 @@ public class GetValuesAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        => ImmutableArray.Create(Rule, UsageAnalyzerConfig.ConfigDescriptor);
+        => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
     {

--- a/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/GetValuesAsUnderlyingTypeAnalyzer.cs
+++ b/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/GetValuesAsUnderlyingTypeAnalyzer.cs
@@ -21,7 +21,7 @@ public class GetValuesAsUnderlyingTypeAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        => ImmutableArray.Create(Rule, UsageAnalyzerConfig.ConfigDescriptor);
+        => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
     {

--- a/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/HasFlagAnalyzer.cs
+++ b/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/HasFlagAnalyzer.cs
@@ -21,7 +21,7 @@ public class HasFlagAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        => ImmutableArray.Create(Rule, UsageAnalyzerConfig.ConfigDescriptor);
+        => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
     {

--- a/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/IsDefinedAnalyzer.cs
+++ b/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/IsDefinedAnalyzer.cs
@@ -21,7 +21,7 @@ public class IsDefinedAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        => ImmutableArray.Create(Rule, UsageAnalyzerConfig.ConfigDescriptor);
+        => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
     {

--- a/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/ParseAnalyzer.cs
+++ b/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/ParseAnalyzer.cs
@@ -21,7 +21,7 @@ public class ParseAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        => ImmutableArray.Create(Rule, UsageAnalyzerConfig.ConfigDescriptor);
+        => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
     {

--- a/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/ToStringAnalyzer.cs
+++ b/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/ToStringAnalyzer.cs
@@ -21,7 +21,7 @@ public class ToStringAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        => ImmutableArray.Create(Rule, UsageAnalyzerConfig.ConfigDescriptor);
+        => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
     {

--- a/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/TryParseAnalyzer.cs
+++ b/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/TryParseAnalyzer.cs
@@ -21,7 +21,7 @@ public class TryParseAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        => ImmutableArray.Create(Rule, UsageAnalyzerConfig.ConfigDescriptor);
+        => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
     {

--- a/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/UsageAnalyzerConfig.cs
+++ b/src/NetEscapades.EnumGenerators/Diagnostics/UsageAnalyzers/UsageAnalyzerConfig.cs
@@ -6,27 +6,7 @@ namespace NetEscapades.EnumGenerators.Diagnostics.UsageAnalyzers;
 public static class UsageAnalyzerConfig
 {
     public const DiagnosticSeverity DefaultSeverity = DiagnosticSeverity.Warning;
-    public const string EnableKey = "netescapades.enumgenerators.usage_analyzers.enable";
-
-    internal static readonly DiagnosticDescriptor ConfigDescriptor = new(
-#pragma warning disable RS2008 // Enable Analyzer Release Tracking
-        id: "NEEGCONFIG001",
-#pragma warning restore RS2008
-        title: "Enable callsite analyzers for generated enum extensions",
-        messageFormat:
-        "Enable analyzers to encourage use of generated extension methods instead of System.Enum methods",
-        category: "Configuration",
-        defaultSeverity: DiagnosticSeverity.Hidden,
-        isEnabledByDefault: true,
-        customTags:
-        [
-            "EditorConfigOption",
-            "EditorConfigOptionKey=netescapades.enumgenerators.usage_analyzers.enable",
-            "EditorConfigOptionDescription=Enable callsite analyzers for generated enum extensions",
-            "EditorConfigOptionAllowedValues=true,false",
-            "EditorConfigOptionDefault=false",
-            WellKnownDiagnosticTags.NotConfigurable
-        ]);
+    public const string EnableKey = "build_property.EnumGenerator_EnableUsageAnalyzers";
 
     internal static bool IsEnabled(AnalyzerOptions context)
         => context.AnalyzerConfigOptionsProvider.GlobalOptions.TryGetValue(EnableKey, out var value) &&

--- a/src/NetEscapades.EnumGenerators/NetEscapades.EnumGenerators.props
+++ b/src/NetEscapades.EnumGenerators/NetEscapades.EnumGenerators.props
@@ -6,5 +6,6 @@
   <ItemGroup>
     <CompilerVisibleProperty Include="EnumGenerator_EnumMetadataSource" />
     <CompilerVisibleProperty Include="EnumGenerator_ForceExtensionMembers" />
+    <CompilerVisibleProperty Include="EnumGenerator_EnableUsageAnalyzers" />
   </ItemGroup>
 </Project>

--- a/src/NetEscapades.EnumGenerators/README.md
+++ b/src/NetEscapades.EnumGenerators/README.md
@@ -306,14 +306,15 @@ _NetEscapades.EnumGenerators_ includes optional analyzers that encourage the use
 
 ### Enabling the analyzers
 
-The usage analyzers are disabled by default. To enable them, [add a `.globalconfig` file](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig) to your project with the following content:
+The usage analyzers are disabled by default. To enable them, set the `EnumGenerator_EnableUsageAnalyzers` MSBuild property to `true` in your project:
 
-```ini
-is_global = true
-netescapades.enumgenerators.usage_analyzers.enable = true
+```xml
+<PropertyGroup>
+  <EnumGenerator_EnableUsageAnalyzers>true</EnumGenerator_EnableUsageAnalyzers>
+</PropertyGroup>
 ```
 
-Your project should automatically detect this configuration file, and enable all the usage analyzers with the default severity of `Warning`.
+After adding this configuration, the analyzers in your project should be enabled with the default severity of `Warning`.
 
 ### Configuring analyzer severity (optional)
 

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/.globalconfig
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/.globalconfig
@@ -1,2 +1,0 @@
-is_global = true
-netescapades.enumgenerators.usage_analyzers.enable = true

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/NetEscapades.EnumGenerators.IntegrationTests.csproj
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/NetEscapades.EnumGenerators.IntegrationTests.csproj
@@ -6,9 +6,11 @@
     <DefineConstants Condition="'$(TargetFramework)' != 'net48'">$(DefineConstants);READONLYSPAN;</DefineConstants>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <EnumGenerator_EnumMetadataSource>EnumMemberAttribute</EnumGenerator_EnumMetadataSource>
+    <EnumGenerator_EnableUsageAnalyzers>true</EnumGenerator_EnableUsageAnalyzers>
   </PropertyGroup>
   <ItemGroup>
     <CompilerVisibleProperty Include="EnumGenerator_EnumMetadataSource" />
+    <CompilerVisibleProperty Include="EnumGenerator_EnableUsageAnalyzers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NetEscapades.EnumGenerators.Nuget.IntegrationTests/NetEscapades.EnumGenerators.Nuget.IntegrationTests.csproj
+++ b/tests/NetEscapades.EnumGenerators.Nuget.IntegrationTests/NetEscapades.EnumGenerators.Nuget.IntegrationTests.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <DefineConstants>$(DefineConstants);NUGET_INTEGRATION_TESTS</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' != 'net48'">$(DefineConstants);READONLYSPAN</DefineConstants>
+    <EnumGenerator_EnableUsageAnalyzers>true</EnumGenerator_EnableUsageAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Using a globalconfig feels cumbersome, just use MSBuild like the rest of the config does. This only works if you're using a modern SDK, but there's no good reason to use this if you're not anyway, so meh.

Fixes #221