### PR TITLE
Add static ReadOnlySpan<> extensions 

### DIFF
--- a/src/NetEscapades.EnumGenerators.Generators/SourceGenerationHelper.cs
+++ b/src/NetEscapades.EnumGenerators.Generators/SourceGenerationHelper.cs
@@ -1968,6 +1968,40 @@ public static class SourceGenerationHelper
         }
 
         AddArrayCloser(sb, useCollectionExpressions);
+            sb.Append(
+                """
+
+
+                    #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    /// <summary>
+                    /// Retrieves a ReadOnlySpan of the values of the members defined in
+                    /// <see cref="
+                    """).Append(fullyQualifiedName).Append(
+            """
+            " />.
+                    /// </summary>
+                    /// <returns>A ReadOnlySpan of the values defined in <see cref="
+            """).Append(fullyQualifiedName).Append(
+            """
+            " /></returns>
+                    public static global::System.ReadOnlySpan<
+            """).Append(fullyQualifiedName).Append('>').Append(" GetValuesSpan()=>");
+        AddArrayOpener(sb, useCollectionExpressions);
+        foreach (var member in orderedNames)
+        {
+            sb.Append(
+                """
+
+                                
+                """).Append(fullyQualifiedName).Append('.').AppendIdentifier(member.Key).Append(',');
+        }
+
+        AddArrayCloser(sb, useCollectionExpressions);
+        sb.Append("""
+                  
+                  #endif
+                  
+                  """);
 
         sb.Append(
             """
@@ -2005,6 +2039,41 @@ public static class SourceGenerationHelper
         }
 
         AddArrayCloser(sb, useCollectionExpressions);
+
+        sb.Append(
+            """
+
+
+            #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            /// <summary>
+            /// Retrieves a ReadOnlySpan of the underlying-values of the members defined in
+            /// <see cref="
+            """).Append(fullyQualifiedName).Append(
+            """
+            " />.
+                    /// </summary>
+                    /// <returns>A ReadOnlySpan of the underlying-values of the members defined in <see cref="
+            """).Append(fullyQualifiedName).Append(
+            """
+            " /></returns>
+                    public static global::System.ReadOnlySpan<
+            """).Append(enumToGenerate.UnderlyingType).Append('>').Append(" GetValuesAsUnderlyingTypeSpan()=>");
+        AddArrayOpener(sb, useCollectionExpressions);
+        foreach (var member in orderedNames)
+        {
+            sb.Append(
+                """
+
+                                (
+                """).Append(enumToGenerate.UnderlyingType).Append(") ").Append(fullyQualifiedName).Append('.').AppendIdentifier(member.Key).Append(',');
+        }
+
+        AddArrayCloser(sb, useCollectionExpressions);
+        sb.Append("""
+
+                  #endif
+
+                  """);
 
         sb.Append(
             """

--- a/tests/NetEscapades.EnumGenerators.Benchmarks/Program.cs
+++ b/tests/NetEscapades.EnumGenerators.Benchmarks/Program.cs
@@ -122,7 +122,7 @@ public class IsDefinedNameFromSpanBenchmark
     public bool EnumIsDefinedNameDisplayNameWithReflection()
     {
         ReadOnlySpan<char> _enumAsSpan = _enumDisplayName;
-        return EnumHelper<TestEnum>.TryParseByDisplayName(_enumAsSpan.ToString(), ignoreCase:false, out _);
+        return EnumHelper<TestEnum>.TryParseByDisplayName(_enumAsSpan.ToString(), ignoreCase: false, out _);
     }
 
     [Benchmark]
@@ -174,6 +174,14 @@ public class GetValuesBenchmark
     {
         return TestEnumExtensions.GetValues();
     }
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+    [Benchmark]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public ReadOnlySpan<TestEnum> ExtensionsGetValuesSpan()
+    {
+        return TestEnumExtensions.GetValuesSpan();
+    }
+#endif
 }
 
 [MemoryDiagnoser]
@@ -208,6 +216,16 @@ public class GetValuesAsUnderlyingTypeBenchmark
     {
         return TestEnumExtensions.GetValuesAsUnderlyingType();
     }
+
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+    [Benchmark]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public ReadOnlySpan<int> ExtensionsGetValuesAsUnderlyingTypeSpan()
+    {
+        return TestEnumExtensions.GetValuesAsUnderlyingTypeSpan();
+    }
+#endif
+
 }
 
 [MemoryDiagnoser]
@@ -282,6 +300,7 @@ public class TryParseBenchmark
             ? result
             : default;
     }
+
     [Benchmark]
     [MethodImpl(MethodImplOptions.NoInlining)]
     public TestEnum ExtensionsTryParseDisplayNameOptions()
@@ -407,7 +426,7 @@ public class TryParseIgnoreCaseBenchmark
     [MethodImpl(MethodImplOptions.NoInlining)]
     public TestEnum ExtensionsTryParseIgnoreCaseDisplayNameOptions()
     {
-        return TestEnumExtensions.TryParse("2ND", out TestEnum result,  new EnumParseOptions(comparisonType: StringComparison.OrdinalIgnoreCase, allowMatchingMetadataAttribute: true))
+        return TestEnumExtensions.TryParse("2ND", out TestEnum result, new EnumParseOptions(comparisonType: StringComparison.OrdinalIgnoreCase, allowMatchingMetadataAttribute: true))
             ? result
             : default;
     }

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInFooExtensionEverythingTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInFooExtensionEverythingTests.cs
@@ -38,7 +38,12 @@ public class EnumInFooExtensionEverythingTests : EnumInFooExtensionsTests
 {
     protected override string[] GetNames() => EnumInFoo.GetNames();
     protected override EnumInFoo[] GetValues() => EnumInFoo.GetValues();
+    #if READONLYSPAN
+    protected override ReadOnlySpan<EnumInFoo> GetValuesSpan() => EnumInFoo.GetValuesSpan();
+    protected override ReadOnlySpan<int> GetValuesAsUnderlyingTypeSpan() => EnumInFoo.GetValuesAsUnderlyingTypeSpan();
+    #endif
     protected override int[] GetValuesAsUnderlyingType() => EnumInFoo.GetValuesAsUnderlyingType();
+
     protected override int AsUnderlyingValue(EnumInFoo value) => value.AsUnderlyingType();
 
     protected override string ToStringFast(EnumInFoo value) => value.ToStringFast();

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInFooExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInFooExtensionsTests.cs
@@ -62,7 +62,12 @@ public class EnumInFooExtensionsTests : ExtensionTests<EnumInFoo, int, EnumInFoo
 
     protected override string[] GetNames() => EnumInFooExtensions.GetNames();
     protected override EnumInFoo[] GetValues() => EnumInFooExtensions.GetValues();
+    #if READONLYSPAN
+    protected override ReadOnlySpan<EnumInFoo> GetValuesSpan() => EnumInFooExtensions.GetValuesSpan();
+    protected override ReadOnlySpan<int> GetValuesAsUnderlyingTypeSpan() => EnumInFooExtensions.GetValuesAsUnderlyingTypeSpan();
+    #endif
     protected override int[] GetValuesAsUnderlyingType() => EnumInFooExtensions.GetValuesAsUnderlyingType();
+
     protected override int AsUnderlyingValue(EnumInFoo value) => value.AsUnderlyingType();
 
     protected override string ToStringFast(EnumInFoo value) => value.ToStringFast();

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumInNamespaceExtensionsTests.cs
@@ -65,7 +65,13 @@ public class EnumInNamespaceExtensionsTests : ExtensionTests<EnumInNamespace, in
 
     protected override string[] GetNames() => EnumInNamespaceExtensions.GetNames();
     protected override EnumInNamespace[] GetValues() => EnumInNamespaceExtensions.GetValues();
+#if READONLYSPAN
+    protected override ReadOnlySpan<EnumInNamespace> GetValuesSpan() => EnumInNamespaceExtensions.GetValuesSpan();
+    protected override ReadOnlySpan<int> GetValuesAsUnderlyingTypeSpan() => EnumInNamespaceExtensions.GetValuesAsUnderlyingTypeSpan();
+#endif
+
     protected override int[] GetValuesAsUnderlyingType() => EnumInNamespaceExtensions.GetValuesAsUnderlyingType();
+
     protected override int AsUnderlyingValue(EnumInNamespace value) => value.AsUnderlyingType();
 
     protected override string ToStringFast(EnumInNamespace value) => value.ToStringFast();

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDescriptionInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDescriptionInNamespaceExtensionsTests.cs
@@ -66,6 +66,10 @@ public class EnumWithDescriptionInNamespaceExtensionsTests : ExtensionTests<Enum
 
     protected override string[] GetNames() => EnumWithDescriptionInNamespaceExtensions.GetNames();
     protected override EnumWithDescriptionInNamespace[] GetValues() => EnumWithDescriptionInNamespaceExtensions.GetValues();
+    #if READONLYSPAN
+    protected override ReadOnlySpan<EnumWithDescriptionInNamespace> GetValuesSpan() => EnumWithDescriptionInNamespaceExtensions.GetValuesSpan();
+    protected override ReadOnlySpan<int> GetValuesAsUnderlyingTypeSpan() => EnumWithDescriptionInNamespaceExtensions.GetValuesAsUnderlyingTypeSpan();
+    #endif
     protected override int[] GetValuesAsUnderlyingType() => EnumWithDescriptionInNamespaceExtensions.GetValuesAsUnderlyingType();
     protected override int AsUnderlyingValue(EnumWithDescriptionInNamespace value) => value.AsUnderlyingType();
 

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDisplayNameInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithDisplayNameInNamespaceExtensionsTests.cs
@@ -65,6 +65,10 @@ public class EnumWithDisplayNameInNamespaceExtensionsTests : ExtensionTests<Enum
 
     protected override string[] GetNames() => EnumWithDisplayNameInNamespaceExtensions.GetNames();
     protected override EnumWithDisplayNameInNamespace[] GetValues() => EnumWithDisplayNameInNamespaceExtensions.GetValues();
+    #if READONLYSPAN
+    protected override ReadOnlySpan<EnumWithDisplayNameInNamespace> GetValuesSpan() => EnumWithDisplayNameInNamespaceExtensions.GetValuesSpan();
+    protected override ReadOnlySpan<int> GetValuesAsUnderlyingTypeSpan() => EnumWithDisplayNameInNamespaceExtensions.GetValuesAsUnderlyingTypeSpan();
+    #endif
     protected override int[] GetValuesAsUnderlyingType() => EnumWithDisplayNameInNamespaceExtensions.GetValuesAsUnderlyingType();
     protected override int AsUnderlyingValue(EnumWithDisplayNameInNamespace value) => value.AsUnderlyingType();
 

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithEnumMemberInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithEnumMemberInNamespaceExtensionsTests.cs
@@ -66,6 +66,10 @@ public class EnumWithEnumMemberInNamespaceExtensionsTests : ExtensionTests<EnumW
 
     protected override string[] GetNames() => EnumWithEnumMemberInNamespaceExtensions.GetNames();
     protected override EnumWithEnumMemberInNamespace[] GetValues() => EnumWithEnumMemberInNamespaceExtensions.GetValues();
+    #if READONLYSPAN
+    protected override ReadOnlySpan<EnumWithEnumMemberInNamespace> GetValuesSpan() => EnumWithEnumMemberInNamespaceExtensions.GetValuesSpan();
+    protected override ReadOnlySpan<int> GetValuesAsUnderlyingTypeSpan() => EnumWithEnumMemberInNamespaceExtensions.GetValuesAsUnderlyingTypeSpan();
+    #endif
     protected override int[] GetValuesAsUnderlyingType() => EnumWithEnumMemberInNamespaceExtensions.GetValuesAsUnderlyingType();
     protected override int AsUnderlyingValue(EnumWithEnumMemberInNamespace value) => value.AsUnderlyingType();
 

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithNoMetadataSourcesInNamespaceExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithNoMetadataSourcesInNamespaceExtensionsTests.cs
@@ -68,7 +68,12 @@ public class EnumWithNoMetadataSourcesInNamespaceExtensionsTests : ExtensionTest
 
     protected override string[] GetNames() => EnumWithNoMetadataSourcesExtensions.GetNames();
     protected override EnumWithNoMetadataSources[] GetValues() => EnumWithNoMetadataSourcesExtensions.GetValues();
+    #if READONLYSPAN
+    protected override ReadOnlySpan<EnumWithNoMetadataSources> GetValuesSpan() => EnumWithNoMetadataSourcesExtensions.GetValuesSpan();
+    protected override ReadOnlySpan<int> GetValuesAsUnderlyingTypeSpan() => EnumWithNoMetadataSourcesExtensions.GetValuesAsUnderlyingTypeSpan();
+    #endif
     protected override int[] GetValuesAsUnderlyingType() => EnumWithNoMetadataSourcesExtensions.GetValuesAsUnderlyingType();
+
     protected override int AsUnderlyingValue(EnumWithNoMetadataSources value) => value.AsUnderlyingType();
 
     // Can't call the "withMetadata" versions of all these

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithReservedKeywordsExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithReservedKeywordsExtensionsTests.cs
@@ -64,6 +64,10 @@ public class EnumWithReservedKeywordsExtensionsTests : ExtensionTests<EnumWithRe
 
     protected override string[] GetNames() => EnumWithReservedKeywordsExtensions.GetNames();
     protected override EnumWithReservedKeywords[] GetValues() => EnumWithReservedKeywordsExtensions.GetValues();
+    #if READONLYSPAN
+    protected override ReadOnlySpan<EnumWithReservedKeywords> GetValuesSpan() => EnumWithReservedKeywordsExtensions.GetValuesSpan();
+    protected override ReadOnlySpan<int> GetValuesAsUnderlyingTypeSpan() => EnumWithReservedKeywordsExtensions.GetValuesAsUnderlyingTypeSpan();
+    #endif
     protected override int[] GetValuesAsUnderlyingType() => EnumWithReservedKeywordsExtensions.GetValuesAsUnderlyingType();
     protected override int AsUnderlyingValue(EnumWithReservedKeywords value) => value.AsUnderlyingType();
 

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithSameDisplayNameExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/EnumWithSameDisplayNameExtensionsTests.cs
@@ -67,6 +67,10 @@ public class EnumWithSameDisplayNameExtensionsTests : ExtensionTests<EnumWithSam
 
     protected override string[] GetNames() => EnumWithSameDisplayNameExtensions.GetNames();
     protected override EnumWithSameDisplayName[] GetValues() => EnumWithSameDisplayNameExtensions.GetValues();
+    #if READONLYSPAN
+    protected override ReadOnlySpan<EnumWithSameDisplayName> GetValuesSpan() => EnumWithSameDisplayNameExtensions.GetValuesSpan();
+    protected override ReadOnlySpan<int> GetValuesAsUnderlyingTypeSpan() => EnumWithSameDisplayNameExtensions.GetValuesAsUnderlyingTypeSpan();
+    #endif
     protected override int[] GetValuesAsUnderlyingType() => EnumWithSameDisplayNameExtensions.GetValuesAsUnderlyingType();
     protected override int AsUnderlyingValue(EnumWithSameDisplayName value) => value.AsUnderlyingType();
 

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/ExtensionTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/ExtensionTests.cs
@@ -41,7 +41,13 @@ public abstract class ExtensionTests<T, TUnderlying, TITestData>
 
     protected abstract string[] GetNames();
     protected abstract T[] GetValues();
+    #if READONLYSPAN
+    protected abstract ReadOnlySpan<T> GetValuesSpan();
+    protected abstract ReadOnlySpan<TUnderlying> GetValuesAsUnderlyingTypeSpan();
+    #endif
+
     protected abstract TUnderlying[] GetValuesAsUnderlyingType();
+
     protected abstract string ToStringFast(T value);
     protected abstract string ToStringFast(T value, bool withMetadata);
     protected abstract string ToStringFast(T value, SerializationOptions options);
@@ -160,8 +166,17 @@ public abstract class ExtensionTests<T, TUnderlying, TITestData>
     [Fact]
     public void GeneratesGetValues() => GeneratesGetValuesTest(GetValues());
 
+    #if READONLYSPAN
+    [Fact]
+    public void GeneratesGetValuesSpan()=> GeneratesGetValuesSpanTest(GetValuesSpan());
+    [Fact]
+    public void GeneratesGetValuesAsUnderlyingTypeSpan() => GeneratesGetValuesAsUnderlyingTypeSpanTest(GetValuesAsUnderlyingTypeSpan());
+    #endif
+
     [Fact]
     public void GeneratesGetValuesAsUnderlyingType() => GeneratesGetValuesAsUnderlyingTypeTest(GetValuesAsUnderlyingType());
+
+
 
     [Fact]
     public void GeneratesGetNames() => GeneratesGetNamesTest(GetNames());
@@ -575,6 +590,31 @@ public abstract class ExtensionTests<T, TUnderlying, TITestData>
         var expected = (T[]) Enum.GetValues(typeof(T));
         values.Should().Equal(expected);
     }
+
+    #if READONLYSPAN
+    private void GeneratesGetValuesSpanTest(ReadOnlySpan<T> values)
+    {
+        var expected = (T[])Enum.GetValues(typeof(T));
+        values.Length.Should().Be(expected.Length);
+        for (var i = 0; i < expected.Length; i++)
+        {
+            values[i].Should().Be(expected[i]);
+        }
+    }
+    private void GeneratesGetValuesAsUnderlyingTypeSpanTest(ReadOnlySpan<TUnderlying> values)
+    {
+#if NET7_OR_GREATER
+        var expected = (TUnderlying[]) Enum.GetValuesAsUnderlyingType(typeof(T));
+#else
+        var expected = Enum.GetValues(typeof(T)).Cast<TUnderlying>().ToArray();
+#endif
+        values.Length.Should().Be(expected.Length);
+        for (var i = 0; i < expected.Length; i++)
+        {
+            values[i].Should().Be(expected[i]);
+        }
+    }
+    #endif
 
     private void GeneratesGetValuesAsUnderlyingTypeTest(TUnderlying[] values)
     {

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/ExternalEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/ExternalEnumExtensionsTests.cs
@@ -66,6 +66,10 @@ public class ExternalEnumExtensionsTests : ExtensionTests<DateTimeKind, int, Ext
 
     protected override string[] GetNames() => DateTimeKindExtensions.GetNames();
     protected override DateTimeKind[] GetValues() => DateTimeKindExtensions.GetValues();
+    #if READONLYSPAN
+    protected override ReadOnlySpan<DateTimeKind> GetValuesSpan() => DateTimeKindExtensions.GetValuesSpan();
+    protected override ReadOnlySpan<int> GetValuesAsUnderlyingTypeSpan() => DateTimeKindExtensions.GetValuesAsUnderlyingTypeSpan();
+    #endif
     protected override int[] GetValuesAsUnderlyingType() => DateTimeKindExtensions.GetValuesAsUnderlyingType();
     protected override int AsUnderlyingValue(DateTimeKind value) => value.AsUnderlyingType();
 

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/ExternalFlagsEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/ExternalFlagsEnumExtensionsTests.cs
@@ -72,6 +72,10 @@ public class ExternalFileShareExtensionsTests : ExtensionTests<FileShare, int, E
 
     protected override string[] GetNames() => FileShareExtensions.GetNames();
     protected override FileShare[] GetValues() => FileShareExtensions.GetValues();
+    #if READONLYSPAN
+    protected override ReadOnlySpan<FileShare> GetValuesSpan() => FileShareExtensions.GetValuesSpan();
+    protected override ReadOnlySpan<int> GetValuesAsUnderlyingTypeSpan() => FileShareExtensions.GetValuesAsUnderlyingTypeSpan();
+    #endif
     protected override int[] GetValuesAsUnderlyingType() => FileShareExtensions.GetValuesAsUnderlyingType();
     protected override int AsUnderlyingValue(FileShare value) => value.AsUnderlyingType();
 

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/FlagsEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/FlagsEnumExtensionsTests.cs
@@ -76,6 +76,10 @@ public class FlagsEnumExtensionsTests : ExtensionTests<FlagsEnum, int, FlagsEnum
 
     protected override string[] GetNames() => FlagsEnumExtensions.GetNames();
     protected override FlagsEnum[] GetValues() => FlagsEnumExtensions.GetValues();
+    #if READONLYSPAN
+    protected override ReadOnlySpan<FlagsEnum> GetValuesSpan() => FlagsEnumExtensions.GetValuesSpan();
+    protected override ReadOnlySpan<int> GetValuesAsUnderlyingTypeSpan() => FlagsEnumExtensions.GetValuesAsUnderlyingTypeSpan();
+    #endif
     protected override int[] GetValuesAsUnderlyingType() => FlagsEnumExtensions.GetValuesAsUnderlyingType();
     protected override int AsUnderlyingValue(FlagsEnum value) => value.AsUnderlyingType();
 

--- a/tests/NetEscapades.EnumGenerators.IntegrationTests/LongEnumExtensionsTests.cs
+++ b/tests/NetEscapades.EnumGenerators.IntegrationTests/LongEnumExtensionsTests.cs
@@ -66,6 +66,10 @@ public class LongEnumExtensionsTests : ExtensionTests<LongEnum, long, LongEnumEx
 
     protected override string[] GetNames() => LongEnumExtensions.GetNames();
     protected override LongEnum[] GetValues() => LongEnumExtensions.GetValues();
+    #if READONLYSPAN
+    protected override ReadOnlySpan<LongEnum> GetValuesSpan() => LongEnumExtensions.GetValuesSpan();
+    protected override ReadOnlySpan<long> GetValuesAsUnderlyingTypeSpan() => LongEnumExtensions.GetValuesAsUnderlyingTypeSpan();
+    #endif
     protected override long[] GetValuesAsUnderlyingType() => LongEnumExtensions.GetValuesAsUnderlyingType();
     protected override long AsUnderlyingValue(LongEnum value) => value.AsUnderlyingType();
 


### PR DESCRIPTION
I often times use the EnumExtensions for a loop and then end up having to declare my own `static readonly` array so that I don't allocate.

This adds extension methods for `GetValues` and `GetValuesAsUnderlyingType` in a `Span` variety.

(also associated tests & benchmarks) 

Benchmarks have the desired impact 😄 

I didn't do a `Names` variation because you can't do a collection expression with `string`.... 

The alternative would be to add something like ....

```
private static readonly _namesForSpan = [nameof(x), nameof(y)...];

public static ReadOnlySpan<string> GetNamesSpan()=> _namesForSpan;
```

Which I believe would accomplish the one-time allocation with the readonly-ness, but that would technically force an allocation on all enums and use up some extra memory (I think).... It may be a useful option for the attribute, but didn't want to go that route just yet.

### Benchmark Results:

<img width="1103" height="239" alt="Screenshot 2026-02-24 at 18 09 17" src="https://github.com/user-attachments/assets/9c60ff17-9866-4b6c-a0d4-f16f12296e05" />
<img width="909" height="233" alt="Screenshot 2026-02-24 at 18 09 07" src="https://github.com/user-attachments/assets/05bbfaa5-8b4e-4b27-bea9-14ebdb652f55" />
